### PR TITLE
fix: Declare react types

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -1,4 +1,5 @@
 {
   "main": "dist/miniplex-react.cjs.js",
-  "module": "dist/miniplex-react.esm.js"
+  "module": "dist/miniplex-react.esm.js",
+  "types": "dist/miniplex-react.cjs.d.ts"
 }


### PR DESCRIPTION
Adds `types` to the `react/package.json` file. This enables automatic type mapping for [Deno](https://deno.land/) when served from [esm.sh](https://esm.sh/).