### PR TITLE
Refactor of the internal component used by Miniplex

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/violet-dodos-hug.md
+++ b/.changeset/violet-dodos-hug.md
@@ -1,0 +1,5 @@
+---
+"miniplex": minor
+---
+
+No more IEntity

--- a/.changeset/violet-dodos-hug.md
+++ b/.changeset/violet-dodos-hug.md
@@ -2,4 +2,4 @@
 "miniplex": minor
 ---
 
-You no longer need to mix in `IEntity` into your own entity types, as part of a wider refactoring of the library's typings.
+**Typescript:** You no longer need to mix in `IEntity` into your own entity types, as part of a wider refactoring of the library's typings. Also, `createWorld` will now return a `RegisteredEntity<YourEntity>` type that reflects the presence of the automatically added `miniplex` component, and makes a lot of interactions with the world instance safer than it was previously.

--- a/.changeset/violet-dodos-hug.md
+++ b/.changeset/violet-dodos-hug.md
@@ -2,4 +2,4 @@
 "miniplex": minor
 ---
 
-No more IEntity
+You no longer need to mix in `IEntity` into your own entity types, as part of a wider refactoring of the library's typings.

--- a/.changeset/violet-dodos-hug2.md
+++ b/.changeset/violet-dodos-hug2.md
@@ -1,0 +1,5 @@
+---
+"miniplex": minor
+---
+
+**Breaking Change:** Miniplex will no longer automatically add an `id` component to created entities. Instead, it will add a `miniplex` entity that contains an `id` property, among other data that is mostly used internally. If you've been using `entity.id` in your code, you'll need to update it to use `entity.miniplex.id`.

--- a/packages/miniplex-react/test/createECS.test.tsx
+++ b/packages/miniplex-react/test/createECS.test.tsx
@@ -1,10 +1,10 @@
 import "@testing-library/jest-dom"
 import { render, screen } from "@testing-library/react"
 import { act } from "react-dom/test-utils"
-import { IEntity, Tag } from "miniplex"
+import { Tag } from "miniplex"
 import { createECS } from "../src/createECS"
 
-type Entity = { name: string } & IEntity
+type Entity = { name: string }
 
 describe("createECS", () => {
   it("returns a useArchetype function", () => {
@@ -73,7 +73,7 @@ describe("createECS", () => {
       )
 
       expect(alice.label).toBeInstanceOf(HTMLParagraphElement)
-      expect(alice.label.textContent).toEqual("Hello")
+      expect(alice.label?.textContent).toEqual("Hello")
     })
 
     it("when passed a React child, it is also possible to pass a render function", () => {
@@ -89,7 +89,7 @@ describe("createECS", () => {
       )
 
       expect(alice.label).toBeInstanceOf(HTMLParagraphElement)
-      expect(alice.label.textContent).toEqual("Alice")
+      expect(alice.label?.textContent).toEqual("Alice")
     })
   })
 
@@ -107,8 +107,8 @@ describe("createECS", () => {
 
         return (
           <ul>
-            {entities.map(({ id, name }) => (
-              <li key={id} data-testid={`user-${id}`}>
+            {entities.map(({ miniplex, name }) => (
+              <li key={miniplex.id} data-testid={`user-${miniplex.id}`}>
                 {name}
               </li>
             ))}
@@ -164,8 +164,8 @@ describe("createECS", () => {
 
       render(
         <Entities entities={world.entities}>
-          {({ id, name }) => (
-            <p key={id} data-testid={`user-${id}`}>
+          {({ miniplex, name }) => (
+            <p key={miniplex.id} data-testid={`user-${miniplex.id}`}>
               {name}
             </p>
           )}
@@ -186,8 +186,8 @@ describe("createECS", () => {
 
       render(
         <Collection tag="name">
-          {({ id, name }) => (
-            <p key={id} data-testid={`user-${id}`}>
+          {({ miniplex, name }) => (
+            <p key={miniplex.id} data-testid={`user-${miniplex.id}`}>
               {name}
             </p>
           )}
@@ -206,8 +206,8 @@ describe("createECS", () => {
 
       render(
         <Collection tag="name">
-          {({ id, name }) => (
-            <p key={id} data-testid={`user-${id}`}>
+          {({ miniplex, name }) => (
+            <p key={miniplex.id} data-testid={`user-${miniplex.id}`}>
               {name}
             </p>
           )}
@@ -238,7 +238,10 @@ describe("createECS", () => {
             entity.renderCount++
 
             return (
-              <p key={entity.id} data-testid={`user-${entity.id}`}>
+              <p
+                key={entity.miniplex.id}
+                data-testid={`user-${entity.miniplex.id}`}
+              >
                 {entity.name}
               </p>
             )

--- a/packages/miniplex/README.md
+++ b/packages/miniplex/README.md
@@ -79,7 +79,7 @@ type Entity = {
   position: { x: number; y: number; z: number }
   velocity?: { x: number; y: number; z: number }
   health?: number
-} & IEntity
+}
 
 const world = new World<Entity>()
 ```
@@ -94,8 +94,6 @@ Let's create an entity. Note how we're immediately giving it a `position` compon
 const entity = world.createEntity({ position: { x: 0, y: 0, z: 0 } })
 ```
 
-The returned object will be a normal JavaScript object that equals the object passed to `createEntity`, but with an additional `id` property containing a unique numerical identifier.
-
 ### Adding Components
 
 Now let's add a `velocity` component to the entity. Note that we're passing the entity itself, not just its identifier:
@@ -104,7 +102,9 @@ Now let's add a `velocity` component to the entity. Note that we're passing the 
 world.addComponent(entity, { velocity: { x: 10, y: 0, z: 0 } })
 ```
 
-Now the entity has three components: `id`, `position` and `velocity`.
+Now the entity has three components: `position`, `velocity`, and `miniplex`.
+
+**Note on the `miniplex` component:** Every entity that is created by your Miniplex world will automatically receive a `miniplex` component. This component contains some data that is mostly used internally: `entity.miniplex.id` is an auto-generated numerical ID (purely for convenience), `entity.miniplex.world` is a reference to the world, and `entity.miniplex.archetypes` is a list of references to archetypes that are currently storing the entity. You are advised to not mutate these properties, but in some advanced usage patterns they can be very useful.
 
 ### Querying Entities
 

--- a/packages/miniplex/src/Archetype.ts
+++ b/packages/miniplex/src/Archetype.ts
@@ -1,4 +1,5 @@
 import { Signal } from "@hmans/signal"
+import { RegisteredEntity } from "."
 import { entityIsArchetype } from "./util/entityIsArchetype"
 import { ComponentName, EntityWith, IEntity } from "./World"
 
@@ -12,7 +13,9 @@ export class Archetype<
   TQuery extends Query<TEntity> = Query<TEntity>
 > {
   /** A list of entities belonging to this archetype. */
-  public entities = new Array<EntityWith<TEntity, TQuery[number]>>()
+  public entities = new Array<
+    EntityWith<RegisteredEntity<TEntity>, TQuery[number]>
+  >()
 
   /** Listeners on this event are invoked when an entity is added to this archetype's index. */
   public onEntityAdded = Signal<TEntity>()

--- a/packages/miniplex/src/Archetype.ts
+++ b/packages/miniplex/src/Archetype.ts
@@ -26,15 +26,27 @@ export class Archetype<
   constructor(public query: TQuery) {}
 
   public indexEntity(entity: RegisteredEntity<TEntity>) {
-    const isArchetype = entityIsArchetype(entity, this.query)
-    const pos = this.entities.indexOf(entity as any, 0)
+    /* If the entity is of the archetype, it should be indexed by us. */
+    const shouldBeIndexed = entityIsArchetype(entity, this.query)
 
-    if (isArchetype && pos < 0) {
+    /* The entity might already be indexed by us, so let's check. */
+    const isIndexed = entity.miniplex.archetypes.includes(this)
+
+    /* If the entity should be indexed, but isn't, add it. */
+    if (shouldBeIndexed && !isIndexed) {
+      entity.miniplex.archetypes.push(this)
       this.entities.push(entity as any)
       this.onEntityAdded.emit(entity)
-    } else if (!isArchetype && pos >= 0) {
-      this.entities.splice(pos, 1)
+      return
+    }
+
+    /* If the entity should not be indexed, but is, let's remove it. */
+    if (!shouldBeIndexed && isIndexed) {
+      this.entities.splice(this.entities.indexOf(entity as any, 0), 1)
       this.onEntityRemoved.emit(entity)
+      const apos = entity.miniplex.archetypes.indexOf(this, 0)
+      entity.miniplex.archetypes.splice(apos, 1)
+      return
     }
   }
 

--- a/packages/miniplex/src/Archetype.ts
+++ b/packages/miniplex/src/Archetype.ts
@@ -18,14 +18,14 @@ export class Archetype<
   >()
 
   /** Listeners on this event are invoked when an entity is added to this archetype's index. */
-  public onEntityAdded = Signal<TEntity>()
+  public onEntityAdded = Signal<RegisteredEntity<TEntity>>()
 
   /** Listeners on this event are invoked when an entity is removed from this archetype's index. */
-  public onEntityRemoved = Signal<TEntity>()
+  public onEntityRemoved = Signal<RegisteredEntity<TEntity>>()
 
   constructor(public query: TQuery) {}
 
-  public indexEntity(entity: TEntity) {
+  public indexEntity(entity: RegisteredEntity<TEntity>) {
     const isArchetype = entityIsArchetype(entity, this.query)
     const pos = this.entities.indexOf(entity as any, 0)
 
@@ -38,7 +38,7 @@ export class Archetype<
     }
   }
 
-  public removeEntity(entity: TEntity) {
+  public removeEntity(entity: RegisteredEntity<TEntity>) {
     const pos = this.entities.indexOf(entity as any, 0)
     if (pos >= 0) {
       this.entities.splice(pos, 1)

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -181,7 +181,7 @@ export class World<T extends IEntity = UntypedEntity> {
   private queuedCommands = commandQueue()
 
   public queue = {
-    createEntity: (entity: T) => {
+    createEntity: (entity: T): T & Partial<MiniplexComponent> => {
       this.queuedCommands.add(() => this.createEntity(entity))
       return entity
     },

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -139,8 +139,8 @@ export class World<T extends IEntity = UntypedEntity> {
       archetype.removeEntity(entity)
     }
 
-    /* Remove its id component */
-    delete entity.id
+    /* Remove its miniplex component */
+    delete entity.miniplex
   }
 
   public addComponent = (

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -20,6 +20,7 @@ export type MiniplexComponent<T> = {
   miniplex: {
     id: number
     world: World<T>
+    archetypes: Archetype<T>[]
   }
 }
 
@@ -115,7 +116,8 @@ export class World<T extends IEntity = UntypedEntity> {
     /* Assign an ID */
     entity.miniplex = {
       id: this.nextId(),
-      world: this
+      world: this,
+      archetypes: []
     }
 
     /* Store the entity... */

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -4,21 +4,19 @@ import { idGenerator } from "./util/idGenerator"
 import { normalizeQuery } from "./util/normalizeQuery"
 import { WithRequiredKeys } from "./util/types"
 
-/**
- * A base interface for entities, which are just normal JavaScript objects with
- * any number of properties, each of which represents a single component. Miniplex
- * automatically adds an `id` component to entities, which is why entity types
- * must always implement IEntity.
- */
 export interface IEntity {
-  id?: number
+  [key: string]: any
+}
+
+type MiniplexComponent = {
+  id: number
 }
 
 /**
  * For situations where no entity type argument is passed to createWorld, we'll
  * default to an untyped entity type that can hold any component.
  */
-export type UntypedEntity = { [components: string]: ComponentData } & IEntity
+export type UntypedEntity = { [components: string]: ComponentData }
 
 /**
  * Component names are just strings/object property names.
@@ -96,11 +94,14 @@ export class World<T extends IEntity = UntypedEntity> {
 
   /* MUTATION FUNCTIONS */
 
-  public createEntity = (entity: T = {} as T) => {
+  public createEntity = (partial: T = {} as T): T & MiniplexComponent => {
+    /* TODO: remove/change this */
     /* If there already is an ID, raise an error. */
-    if ("id" in entity) {
-      throw "Attempted to add an entity that aleady had an 'id' component."
-    }
+    // if ("id" in entity) {
+    //   throw "Attempted to add an entity that aleady had an 'id' component."
+    // }
+
+    const entity = partial as T & MiniplexComponent
 
     /* Assign an ID */
     entity.id = this.nextId()

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -4,11 +4,19 @@ import { idGenerator } from "./util/idGenerator"
 import { normalizeQuery } from "./util/normalizeQuery"
 import { WithRequiredKeys } from "./util/types"
 
+/**
+ * Entities in Miniplex are just plain old Javascript objects. We are assuming
+ * map-like objects that use string-based properties to identify individual components.
+ */
 export interface IEntity {
-  [key: string]: any
+  [key: string]: ComponentData
 }
 
-type MiniplexComponent = {
+/**
+ * Miniplex uses an internal component that it will automatically add to all created
+ * entities.
+ */
+export type MiniplexComponent = {
   id: number
 }
 

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -16,9 +16,10 @@ export interface IEntity {
  * Miniplex uses an internal component that it will automatically add to all created
  * entities.
  */
-export type MiniplexComponent = {
+export type MiniplexComponent<T> = {
   miniplex: {
     id: number
+    world: World<T>
   }
 }
 
@@ -104,18 +105,19 @@ export class World<T extends IEntity = UntypedEntity> {
 
   /* MUTATION FUNCTIONS */
 
-  public createEntity = (partial: T = {} as T): T & MiniplexComponent => {
+  public createEntity = (partial: T = {} as T): T & MiniplexComponent<T> => {
     /* TODO: remove/change this */
     /* If there already is an ID, raise an error. */
     // if ("id" in entity) {
     //   throw "Attempted to add an entity that aleady had an 'id' component."
     // }
 
-    const entity = partial as T & MiniplexComponent
+    const entity = partial as T & MiniplexComponent<T>
 
     /* Assign an ID */
     entity.miniplex = {
-      id: this.nextId()
+      id: this.nextId(),
+      world: this
     }
 
     /* Store the entity... */
@@ -193,7 +195,7 @@ export class World<T extends IEntity = UntypedEntity> {
   private queuedCommands = commandQueue()
 
   public queue = {
-    createEntity: (entity: T): T & Partial<MiniplexComponent> => {
+    createEntity: (entity: T): T & Partial<MiniplexComponent<T>> => {
       this.queuedCommands.add(() => this.createEntity(entity))
       return entity
     },

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -17,7 +17,9 @@ export interface IEntity {
  * entities.
  */
 export type MiniplexComponent = {
-  id: number
+  miniplex: {
+    id: number
+  }
 }
 
 /**
@@ -112,7 +114,9 @@ export class World<T extends IEntity = UntypedEntity> {
     const entity = partial as T & MiniplexComponent
 
     /* Assign an ID */
-    entity.id = this.nextId()
+    entity.miniplex = {
+      id: this.nextId()
+    }
 
     /* Store the entity... */
     this.entities.push(entity)

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -145,7 +145,7 @@ describe("World", () => {
       world.addComponent(entity, { ...position(1, 2), ...health(100) })
 
       expect(entity).toEqual({
-        miniplex: { id: 1, world },
+        miniplex: { id: 1, world, archetypes: [] },
         position: { x: 1, y: 2 },
         health: { max: 100, current: 100 }
       })
@@ -158,7 +158,7 @@ describe("World", () => {
       world.addComponent(entity, position(1, 2), health(100))
 
       expect(entity).toEqual({
-        miniplex: { id: 1, world },
+        miniplex: { id: 1, world, archetypes: [] },
         position: { x: 1, y: 2 },
         health: { max: 100, current: 100 }
       })

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -28,12 +28,12 @@ describe("World", () => {
     it("creates a new entity", () => {
       const world = new World<Entity>()
       const entity = world.createEntity()
-      expect(entity.id).not.toBeUndefined()
+      expect(entity.miniplex.id).not.toBeUndefined()
     })
 
     it("accepts an object that will become the entity", () => {
       const world = new World<Entity>()
-      const entity: Entity = { name: "Alice" }
+      const entity: Partial<Entity> = { name: "Alice" }
       const returnedEntity = world.createEntity(entity)
       expect(returnedEntity).toBe(entity)
     })
@@ -105,7 +105,10 @@ describe("World", () => {
     it("removes the entity from all archetypes", () => {
       const world = new World<GameObject>()
       const withVelocity = world.archetype("velocity")
-      const entity = world.createEntity({ position: { x: 0, y: 0 }, velocity: { x: 1, y: 2 } })
+      const entity = world.createEntity({
+        position: { x: 0, y: 0 },
+        velocity: { x: 1, y: 2 }
+      })
 
       expect(withVelocity.entities).toContain(entity)
       world.destroyEntity(entity)
@@ -116,7 +119,9 @@ describe("World", () => {
   describe("addComponent", () => {
     const position = (x: number = 0, y: number = 0) => ({ position: { x, y } })
     const velocity = (x: number = 0, y: number = 0) => ({ velocity: { x, y } })
-    const health = (amount: number) => ({ health: { max: amount, current: amount } })
+    const health = (amount: number) => ({
+      health: { max: amount, current: amount }
+    })
 
     it("adds a component expressed as a partial entity", () => {
       const world = new World<GameObject>()
@@ -187,7 +192,10 @@ describe("World", () => {
   describe("removeComponent", () => {
     it("removes a component from an entity", () => {
       const world = new World<GameObject>()
-      const entity = world.createEntity({ position: { x: 0, y: 0 }, velocity: { x: 1, y: 2 } })
+      const entity = world.createEntity({
+        position: { x: 0, y: 0 },
+        velocity: { x: 1, y: 2 }
+      })
       world.removeComponent(entity, "velocity")
       expect(entity.velocity).toBeUndefined()
     })
@@ -195,7 +203,10 @@ describe("World", () => {
     it("removes entities from relevant archetypes", () => {
       const world = new World<GameObject>()
       const withVelocity = world.archetype("velocity")
-      const entity = world.createEntity({ position: { x: 0, y: 0 }, velocity: { x: 1, y: 2 } })
+      const entity = world.createEntity({
+        position: { x: 0, y: 0 },
+        velocity: { x: 1, y: 2 }
+      })
       expect(withVelocity.entities).toContain(entity)
       world.removeComponent(entity, "velocity")
       expect(withVelocity.entities).not.toContain(entity)
@@ -212,7 +223,10 @@ describe("World", () => {
     it("throws when the specified entity is not managed by this world", () => {
       const world = new World<GameObject>()
       const otherWorld = new World<GameObject>()
-      const entity = otherWorld.createEntity({ position: { x: 0, y: 0 }, velocity: { x: 1, y: 2 } })
+      const entity = otherWorld.createEntity({
+        position: { x: 0, y: 0 },
+        velocity: { x: 1, y: 2 }
+      })
       expect(() => {
         world.removeComponent(entity, "velocity")
       }).toThrow()

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -45,10 +45,16 @@ describe("World", () => {
       expect(world.entities).toEqual([entity])
     })
 
-    it("assigns an ID to the entity", () => {
+    it("assigns an ID to the entity's miniplex component", () => {
       const world = new World<Entity>()
       const entity = world.createEntity({ name: "Alice" })
       expect(entity.miniplex.id).toEqual(1)
+    })
+
+    it("assigns a reference to the world to the entity's miniplex component", () => {
+      const world = new World<Entity>()
+      const entity = world.createEntity({ name: "Alice" })
+      expect(entity.miniplex.world).toEqual(world)
     })
 
     it("assigns automatically incrementing IDs", () => {
@@ -139,7 +145,7 @@ describe("World", () => {
       world.addComponent(entity, { ...position(1, 2), ...health(100) })
 
       expect(entity).toEqual({
-        miniplex: { id: 1 },
+        miniplex: { id: 1, world },
         position: { x: 1, y: 2 },
         health: { max: 100, current: 100 }
       })
@@ -152,7 +158,7 @@ describe("World", () => {
       world.addComponent(entity, position(1, 2), health(100))
 
       expect(entity).toEqual({
-        miniplex: { id: 1 },
+        miniplex: { id: 1, world },
         position: { x: 1, y: 2 },
         health: { max: 100, current: 100 }
       })

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -28,7 +28,7 @@ describe("World", () => {
     it("creates a new entity", () => {
       const world = new World<Entity>()
       const entity = world.createEntity()
-      expect(entity.id).not.toBeUndefined()
+      expect(entity.miniplex.id).not.toBeUndefined()
     })
 
     it("accepts an object that will become the entity", () => {
@@ -48,14 +48,14 @@ describe("World", () => {
     it("assigns an ID to the entity", () => {
       const world = new World<Entity>()
       const entity = world.createEntity({ name: "Alice" })
-      expect(entity.id).toEqual(1)
+      expect(entity.miniplex.id).toEqual(1)
     })
 
     it("assigns automatically incrementing IDs", () => {
       const world = new World<Entity>()
       world.createEntity({ name: "Alice" })
       const entity = world.createEntity({ name: "Bob" })
-      expect(entity.id).toEqual(2)
+      expect(entity.miniplex.id).toEqual(2)
     })
 
     describe(".queued", () => {
@@ -71,11 +71,11 @@ describe("World", () => {
       it("does not yet assign an ID", () => {
         const world = new World<Entity>()
         const entity = world.queue.createEntity({ name: "Alice" })
-        expect(entity.id).toBeUndefined()
+        expect(entity.miniplex).toBeUndefined()
 
         /* Flushing won't change the ID */
         world.queue.flush()
-        expect(entity.id).toEqual(1)
+        expect(entity.miniplex!.id).toEqual(1)
       })
     })
   })
@@ -139,7 +139,7 @@ describe("World", () => {
       world.addComponent(entity, { ...position(1, 2), ...health(100) })
 
       expect(entity).toEqual({
-        id: 1,
+        miniplex: { id: 1 },
         position: { x: 1, y: 2 },
         health: { max: 100, current: 100 }
       })
@@ -152,7 +152,7 @@ describe("World", () => {
       world.addComponent(entity, position(1, 2), health(100))
 
       expect(entity).toEqual({
-        id: 1,
+        miniplex: { id: 1 },
         position: { x: 1, y: 2 },
         health: { max: 100, current: 100 }
       })

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -5,7 +5,7 @@ type Entity = {
   name?: string
   age?: number
   admin?: boolean
-} & IEntity
+}
 
 type Vector2 = {
   x: number
@@ -28,7 +28,7 @@ describe("World", () => {
     it("creates a new entity", () => {
       const world = new World<Entity>()
       const entity = world.createEntity()
-      expect(entity.miniplex.id).not.toBeUndefined()
+      expect(entity.id).not.toBeUndefined()
     })
 
     it("accepts an object that will become the entity", () => {


### PR DESCRIPTION
Checklist:

- [x] Improve typings so we don't have to force the user to mix `IEntity` into all their entities, oof
- [x] No longer force an `id` component onto all entities; instead, make it a `miniplex` component, that stores the ID alongside some other data (useful for both the user, but we're going to use it for some performance optimizations)
- [x] Store `miniplex.world` and use it to make sanity checks faster
- [x] Store `miniplex.archetypes` and use it to make sanity checks faster