### PR TITLE
Make `miniplex` component internal as `__miniplex`; allow `createEntity` to accept multiple partial entities; general cleanup

### DIFF
--- a/.changeset/fuzzy-games-burn.md
+++ b/.changeset/fuzzy-games-burn.md
@@ -1,0 +1,5 @@
+---
+"miniplex": minor
+---
+
+**Breaking Change:** `createEntity` will now always return a new object, and not return the one passed to it.

--- a/.changeset/purple-mangos-begin.md
+++ b/.changeset/purple-mangos-begin.md
@@ -4,24 +4,15 @@
 
 `createEntity` now allows you to pass multiple parameters, each representing a partial entity. This makes the use of component factory functions more convenient. Example:
 
-```ts
-/* Define component types */
-type Vector2 = { x: number; y: number }
-type PositionComponent = { position: Vector2 }
-type VelocityComponent = { velocity: Vector2 }
-type HealthComponent = { health: { max: number; current: number } }
-
-/* Define an entity type composed of required and optional components */
-type Entity = PositionComponent & Partial<VelocityComponent, HealthComponent>
-
+```js
 /* Provide a bunch of component factories */
-const position = (x = 0, y = 0): PositionComponent => ({ position: { x, y } })
-const velocity = (x = 0, y = 0): VelocityComponent => ({ velocity: { x, y } })
-const health = (initial: number): HealthComponent => ({
+const position = (x = 0, y = 0) => ({ position: { x, y } })
+const velocity = (x = 0, y = 0) => ({ velocity: { x, y } })
+const health = (initial) => ({
   health: { max: initial, current: initial }
 })
 
-const world = new World<Entity>()
+const world = new World()
 
 const entity = world.createEntity(position(0, 0), velocity(5, 7), health(1000))
 ```

--- a/.changeset/purple-mangos-begin.md
+++ b/.changeset/purple-mangos-begin.md
@@ -1,0 +1,19 @@
+---
+"miniplex": patch
+---
+
+`createEntity` now allows you to pass multiple parameters, each representing a partial entity. This makes the use of component factory functions more convenient. Example:
+
+```ts
+type GameObject = {
+  position: Vector2
+  velocity?: Vector2
+}
+
+const position = (x = 0, y = 0) => ({ position: { x, y } })
+const velocity = (x = 0, y = 0) => ({ velocity: { x, y } })
+
+const world = new World<GameObject>()
+
+const entity = world.createEntity(position(0, 0), velocity(5, 7))
+```

--- a/.changeset/purple-mangos-begin.md
+++ b/.changeset/purple-mangos-begin.md
@@ -5,17 +5,25 @@
 `createEntity` now allows you to pass multiple parameters, each representing a partial entity. This makes the use of component factory functions more convenient. Example:
 
 ```ts
-type GameObject = {
-  position: Vector2
-  velocity?: Vector2
-}
+/* Define component types */
+type Vector2 = { x: number; y: number }
+type PositionComponent = { position: Vector2 }
+type VelocityComponent = { velocity: Vector2 }
+type HealthComponent = { health: { max: number; current: number } }
 
-const position = (x = 0, y = 0) => ({ position: { x, y } })
-const velocity = (x = 0, y = 0) => ({ velocity: { x, y } })
+/* Define an entity type composed of required and optional components */
+type Entity = PositionComponent & Partial<VelocityComponent, HealthComponent>
 
-const world = new World<GameObject>()
+/* Provide a bunch of component factories */
+const position = (x = 0, y = 0): PositionComponent => ({ position: { x, y } })
+const velocity = (x = 0, y = 0): VelocityComponent => ({ velocity: { x, y } })
+const health = (initial: number): HealthComponent => ({
+  health: { max: initial, current: initial }
+})
 
-const entity = world.createEntity(position(0, 0), velocity(5, 7))
+const world = new World<Entity>()
+
+const entity = world.createEntity(position(0, 0), velocity(5, 7), health(1000))
 ```
 
 **Typescript Note:** The first argument will always be typechecked against your entity type, so if your entity type has required components, you will need to pass a first argument that satisfies these. The remaining arguments are expected to be partials of your entity type.

--- a/.changeset/purple-mangos-begin.md
+++ b/.changeset/purple-mangos-begin.md
@@ -17,3 +17,5 @@ const world = new World<GameObject>()
 
 const entity = world.createEntity(position(0, 0), velocity(5, 7))
 ```
+
+**Typescript Note:** The first argument will always be typechecked against your entity type, so if your entity type has required components, you will need to pass a first argument that satisfies these. The remaining arguments are expected to be partials of your entity type.

--- a/.changeset/tricky-deers-dance.md
+++ b/.changeset/tricky-deers-dance.md
@@ -1,0 +1,5 @@
+---
+"miniplex": patch
+---
+
+**Breaking Change:** `world.queue.createEntity` no longer returns an entity (which didn't make a whole lot of semantic change to begin with.)

--- a/.changeset/tricky-deers-dance.md
+++ b/.changeset/tricky-deers-dance.md
@@ -2,4 +2,4 @@
 "miniplex": patch
 ---
 
-**Breaking Change:** `world.queue.createEntity` no longer returns an entity (which didn't make a whole lot of semantic change to begin with.)
+**Breaking Change:** `world.queue.createEntity` no longer returns an entity (which didn't make a whole lot of semantic sense to begin with.)

--- a/.changeset/violet-dodos-hug2.md
+++ b/.changeset/violet-dodos-hug2.md
@@ -3,3 +3,18 @@
 ---
 
 **Breaking Change:** Miniplex will no longer automatically add an `id` component to created entities. If your project has been making use of these automatically generated IDs, you will now need to add them yourself.
+
+Example:
+
+```js
+let nextId = 0
+
+/* Some component factories */
+const id = () => ({ id: nextId++ })
+const name = (name) => ({ name })
+
+const world = new World()
+const entity = world.createEntity(id(), name("Alice"))
+```
+
+**Note:** Keep in mind that Miniplex doesn't care about entity IDs at all, since all interactions with the world are done through object references. Your project may not need to add IDs to entities at all; if it does, this can now be done using any schema that your project requires (numerical IDs, UUIDs, ...).

--- a/.changeset/violet-dodos-hug2.md
+++ b/.changeset/violet-dodos-hug2.md
@@ -2,4 +2,4 @@
 "miniplex": minor
 ---
 
-**Breaking Change:** Miniplex will no longer automatically add an `id` component to created entities. Instead, it will add a `miniplex` entity that contains an `id` property, among other data that is mostly used internally. If you've been using `entity.id` in your code, you'll need to update it to use `entity.miniplex.id`.
+**Breaking Change:** Miniplex will no longer automatically add an `id` component to created entities. If your project has been making use of these automatically generated IDs, you will now need to add them yourself.

--- a/packages/miniplex-react/src/createECS.tsx
+++ b/packages/miniplex-react/src/createECS.tsx
@@ -18,7 +18,6 @@ import {
   Tag,
   Query,
   EntityWith,
-  MiniplexComponent,
   RegisteredEntity
 } from "miniplex"
 import { useConst, useRerender } from "@hmans/react-toolbox"
@@ -63,7 +62,7 @@ export function createECS<TEntity extends IEntity = UntypedEntity>() {
 
   const MemoizedEntity: FC<{ entity: RegisteredEntity<TEntity> }> = memo(
     ({ entity, children }) => (
-      <Entity entity={entity} key={entity.miniplex.id}>
+      <Entity entity={entity} key={entity.__miniplex.id}>
         {typeof children === "function" ? children(entity) : children}
       </Entity>
     ),
@@ -79,7 +78,7 @@ export function createECS<TEntity extends IEntity = UntypedEntity>() {
         {entities.map((entity) => (
           <MemoizedEntity
             entity={entity}
-            key={entity.miniplex.id}
+            key={entity.__miniplex.id}
             children={children}
           />
         ))}

--- a/packages/miniplex-react/test/createECS.test.tsx
+++ b/packages/miniplex-react/test/createECS.test.tsx
@@ -133,7 +133,7 @@ describe("createECS", () => {
       const { world, Users } = setup(() => renderCount++)
 
       /* queue a new entity to be added */
-      const charles = world.queue.createEntity({ name: "Charles" })
+      world.queue.createEntity({ name: "Charles" })
 
       /* Render the component. At this point, Charles has not been added to the page. */
       render(<Users />)
@@ -146,7 +146,7 @@ describe("createECS", () => {
       expect(screen.queryByText("Charles")).toBeInTheDocument()
 
       /* Now remove the entity again and check if the page rerenders. */
-      world.queue.destroyEntity(charles)
+      world.queue.destroyEntity(world.entities[world.entities.length - 1])
       act(() => world.queue.flush())
       expect(screen.queryByText("Charles")).not.toBeInTheDocument()
       expect(renderCount).toEqual(4)

--- a/packages/miniplex-react/test/createECS.test.tsx
+++ b/packages/miniplex-react/test/createECS.test.tsx
@@ -107,8 +107,8 @@ describe("createECS", () => {
 
         return (
           <ul>
-            {entities.map(({ miniplex, name }) => (
-              <li key={miniplex.id} data-testid={`user-${miniplex.id}`}>
+            {entities.map(({ __miniplex, name }) => (
+              <li key={__miniplex.id} data-testid={`user-${__miniplex.id}`}>
                 {name}
               </li>
             ))}
@@ -164,8 +164,8 @@ describe("createECS", () => {
 
       render(
         <Entities entities={world.entities}>
-          {({ miniplex, name }) => (
-            <p key={miniplex.id} data-testid={`user-${miniplex.id}`}>
+          {({ __miniplex, name }) => (
+            <p key={__miniplex.id} data-testid={`user-${__miniplex.id}`}>
               {name}
             </p>
           )}
@@ -186,8 +186,8 @@ describe("createECS", () => {
 
       render(
         <Collection tag="name">
-          {({ miniplex, name }) => (
-            <p key={miniplex.id} data-testid={`user-${miniplex.id}`}>
+          {({ __miniplex, name }) => (
+            <p key={__miniplex.id} data-testid={`user-${__miniplex.id}`}>
               {name}
             </p>
           )}
@@ -206,8 +206,8 @@ describe("createECS", () => {
 
       render(
         <Collection tag="name">
-          {({ miniplex, name }) => (
-            <p key={miniplex.id} data-testid={`user-${miniplex.id}`}>
+          {({ __miniplex, name }) => (
+            <p key={__miniplex.id} data-testid={`user-${__miniplex.id}`}>
               {name}
             </p>
           )}
@@ -239,8 +239,8 @@ describe("createECS", () => {
 
             return (
               <p
-                key={entity.miniplex.id}
-                data-testid={`user-${entity.miniplex.id}`}
+                key={entity.__miniplex.id}
+                data-testid={`user-${entity.__miniplex.id}`}
               >
                 {entity.name}
               </p>

--- a/packages/miniplex/README.md
+++ b/packages/miniplex/README.md
@@ -160,7 +160,33 @@ world.queue.flush()
 
 **Note:** Please remember that the queue is not flushed automatically, and doing this is left to you. You might, for example, do this in your game's main loop, after all systems have finished executing.
 
-## Performance Hints
+## Usage Hints
+
+### Consider using Component Factories
+
+`createEntity` and `addComponent` accept plain Javascript objects, opening the door to some nice patterns for making entities and components nicely composable. For example, you could create a set of functions acting as component factories, like this:
+
+```ts
+/* Define component types */
+type Vector2 = { x: number; y: number }
+type PositionComponent = { position: Vector2 }
+type VelocityComponent = { velocity: Vector2 }
+type HealthComponent = { health: { max: number; current: number } }
+
+/* Define an entity type composed of required and optional components */
+type Entity = PositionComponent & Partial<VelocityComponent, HealthComponent>
+
+/* Provide a bunch of component factories */
+const position = (x = 0, y = 0): PositionComponent => ({ position: { x, y } })
+const velocity = (x = 0, y = 0): VelocityComponent => ({ velocity: { x, y } })
+const health = (initial: number): HealthComponent => ({
+  health: { max: initial, current: initial }
+})
+
+const world = new World<Entity>()
+
+const entity = world.createEntity(position(0, 0), velocity(5, 7), health(1000))
+```
 
 ### Prefer `for` over `forEach`
 

--- a/packages/miniplex/README.md
+++ b/packages/miniplex/README.md
@@ -193,6 +193,8 @@ const other = world.createEntity(position(0, 0))
 world.addComponent(other, velocity(-10, 0), health(500))
 ```
 
+## Performance Hints
+
 ### Prefer `for` over `forEach`
 
 You might be tempted to use `forEach` in your system implementations, like this:

--- a/packages/miniplex/README.md
+++ b/packages/miniplex/README.md
@@ -102,9 +102,9 @@ Now let's add a `velocity` component to the entity. Note that we're passing the 
 world.addComponent(entity, { velocity: { x: 10, y: 0, z: 0 } })
 ```
 
-Now the entity has three components: `position`, `velocity`, and `miniplex`.
+Now the entity has two components: `position` and `velocity`.
 
-**Note on the `miniplex` component:** Every entity that is created by your Miniplex world will automatically receive a `miniplex` component. This component contains some data that is mostly used internally: `entity.miniplex.id` is an auto-generated numerical ID (purely for convenience), `entity.miniplex.world` is a reference to the world, and `entity.miniplex.archetypes` is a list of references to archetypes that are currently storing the entity. You are advised to not mutate these properties, but in some advanced usage patterns they can be very useful.
+**Note:** Once added to the world, entities also automatically receive an internal `__miniplex` component. This component contains data that helps Miniplex track the entity's lifecycle, and optimize a lot of interactions with the world, and you can safely ignore it.
 
 ### Querying Entities
 

--- a/packages/miniplex/README.md
+++ b/packages/miniplex/README.md
@@ -185,7 +185,12 @@ const health = (initial: number): HealthComponent => ({
 
 const world = new World<Entity>()
 
+/* Use these in createEntity */
 const entity = world.createEntity(position(0, 0), velocity(5, 7), health(1000))
+
+/* Use these in addComponent */
+const other = world.createEntity(position(0, 0))
+world.addComponent(other, velocity(-10, 0), health(500))
 ```
 
 ### Prefer `for` over `forEach`

--- a/packages/miniplex/README.md
+++ b/packages/miniplex/README.md
@@ -166,6 +166,24 @@ world.queue.flush()
 
 `createEntity` and `addComponent` accept plain Javascript objects, opening the door to some nice patterns for making entities and components nicely composable. For example, you could create a set of functions acting as component factories, like this:
 
+```js
+/* Provide a bunch of component factories */
+const position = (x = 0, y = 0) => ({ position: { x, y } })
+const velocity = (x = 0, y = 0) => ({ velocity: { x, y } })
+const health = (initial) => ({ health: { max: initial, current: initial } })
+
+const world = new World()
+
+/* Use these in createEntity */
+const entity = world.createEntity(position(0, 0), velocity(5, 7), health(1000))
+
+/* Use these in addComponent */
+const other = world.createEntity(position(0, 0))
+world.addComponent(other, velocity(-10, 0), health(500))
+```
+
+If you're using Typescript, you may even add some per-component types on top like in the following example:
+
 ```ts
 /* Define component types */
 type Vector2 = { x: number; y: number }

--- a/packages/miniplex/package.json
+++ b/packages/miniplex/package.json
@@ -41,12 +41,14 @@
     "@changesets/cli": "^2.22.0",
     "@preconstruct/cli": "^2.1.5",
     "@types/jest": "^27.4.0",
+    "@types/uuid": "^8.3.4",
     "jest": "^27.5.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
     "tslib": "^2.0.3",
     "typedoc": "^0.22.13",
-    "typescript": "^4.6.2"
+    "typescript": "^4.6.2",
+    "uuid": "^8.3.2"
   },
   "dependencies": {
     "@hmans/signal": "^0.1.7"

--- a/packages/miniplex/src/Archetype.ts
+++ b/packages/miniplex/src/Archetype.ts
@@ -30,11 +30,11 @@ export class Archetype<
     const shouldBeIndexed = entityIsArchetype(entity, this.query)
 
     /* The entity might already be indexed by us, so let's check. */
-    const isIndexed = entity.miniplex.archetypes.includes(this)
+    const isIndexed = entity.__miniplex.archetypes.includes(this)
 
     /* If the entity should be indexed, but isn't, add it. */
     if (shouldBeIndexed && !isIndexed) {
-      entity.miniplex.archetypes.push(this)
+      entity.__miniplex.archetypes.push(this)
       this.entities.push(entity as any)
       this.onEntityAdded.emit(entity)
       return
@@ -44,8 +44,8 @@ export class Archetype<
     if (!shouldBeIndexed && isIndexed) {
       this.entities.splice(this.entities.indexOf(entity as any, 0), 1)
       this.onEntityRemoved.emit(entity)
-      const apos = entity.miniplex.archetypes.indexOf(this, 0)
-      entity.miniplex.archetypes.splice(apos, 1)
+      const apos = entity.__miniplex.archetypes.indexOf(this, 0)
+      entity.__miniplex.archetypes.splice(apos, 1)
       return
     }
   }

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -136,7 +136,7 @@ export class World<T extends IEntity = UntypedEntity> {
   }
 
   public destroyEntity = (entity: RegisteredEntity<T> | T) => {
-    if (entity.__miniplex.world !== this) return
+    if (entity.__miniplex?.world !== this) return
 
     /* Remove it from our global list of entities */
     const pos = this.entities.indexOf(entity as RegisteredEntity<T>, 0)
@@ -204,9 +204,8 @@ export class World<T extends IEntity = UntypedEntity> {
   private queuedCommands = commandQueue()
 
   public queue = {
-    createEntity: (entity: T): T & Partial<MiniplexComponent<T>> => {
+    createEntity: (entity: T) => {
       this.queuedCommands.add(() => this.createEntity(entity))
-      return entity
     },
 
     destroyEntity: (entity: RegisteredEntity<T> | T) => {

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -105,7 +105,7 @@ export class World<T extends IEntity = UntypedEntity> {
 
   /* MUTATION FUNCTIONS */
 
-  public createEntity = (
+  public createEntity = <P>(
     base: T = {} as T,
     ...extraComponents: Partial<T>[]
   ): RegisteredEntity<T> => {

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -105,21 +105,25 @@ export class World<T extends IEntity = UntypedEntity> {
 
   /* MUTATION FUNCTIONS */
 
-  public createEntity = (partial: T = {} as T): RegisteredEntity<T> => {
-    /* If there already is a miniplex component on this, bail */
-    if ("miniplex" in partial) {
-      throw new Error(
-        "Attempted to add an entity that aleady has a `miniplex` comonent."
-      )
-    }
+  public createEntity = (
+    base: T = {} as T,
+    ...extraComponents: Partial<T>[]
+  ): RegisteredEntity<T> => {
+    /* Merge all given partials into a single object. */
+    const mergedExtraComponents = extraComponents.reduce(
+      (acc, partial) => ({ ...acc, ...partial }),
+      {} as T
+    )
 
-    const entity = partial as RegisteredEntity<T>
-
-    /* Assign an ID */
-    entity.__miniplex = {
-      id: this.nextId(),
-      world: this,
-      archetypes: []
+    /* Create the entity. */
+    const entity = {
+      ...base,
+      ...mergedExtraComponents,
+      __miniplex: {
+        id: this.nextId(),
+        world: this,
+        archetypes: []
+      }
     }
 
     /* Store the entity... */

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -17,7 +17,7 @@ export interface IEntity {
  * entities.
  */
 export type MiniplexComponent<T> = {
-  miniplex: {
+  __miniplex: {
     id: number
     world: World<T>
     archetypes: Archetype<T>[]
@@ -96,7 +96,7 @@ export class World<T extends IEntity = UntypedEntity> {
     We absolutely never want to add entities to our indices that are not actually
     part of this world, so let's do a sanity check.
     */
-    if (entity.miniplex.world !== this) return
+    if (entity.__miniplex.world !== this) return
 
     for (const archetype of this.archetypes.values()) {
       archetype.indexEntity(entity)
@@ -116,7 +116,7 @@ export class World<T extends IEntity = UntypedEntity> {
     const entity = partial as RegisteredEntity<T>
 
     /* Assign an ID */
-    entity.miniplex = {
+    entity.__miniplex = {
       id: this.nextId(),
       world: this,
       archetypes: []
@@ -131,20 +131,20 @@ export class World<T extends IEntity = UntypedEntity> {
     return entity
   }
 
-  public destroyEntity = (entity: RegisteredEntity<T>) => {
-    if (entity.miniplex.world !== this) return
+  public destroyEntity = (entity: RegisteredEntity<T> | T) => {
+    if (entity.__miniplex.world !== this) return
 
     /* Remove it from our global list of entities */
-    const pos = this.entities.indexOf(entity, 0)
+    const pos = this.entities.indexOf(entity as RegisteredEntity<T>, 0)
     this.entities.splice(pos, 1)
 
     /* Remove entity from all archetypes */
-    for (const archetype of entity.miniplex.archetypes) {
+    for (const archetype of entity.__miniplex.archetypes) {
       archetype.removeEntity(entity)
     }
 
     /* Remove its miniplex component */
-    delete (entity as T).miniplex
+    delete (entity as T).__miniplex
   }
 
   public addComponent = (
@@ -152,7 +152,7 @@ export class World<T extends IEntity = UntypedEntity> {
     ...partials: Partial<T>[]
   ) => {
     /* Sanity check */
-    if (entity.miniplex.world !== this) {
+    if (entity.__miniplex.world !== this) {
       throw `Tried to add components to an entity that is not managed by this world.`
     }
 
@@ -177,7 +177,7 @@ export class World<T extends IEntity = UntypedEntity> {
     entity: RegisteredEntity<T>,
     ...components: ComponentName<T>[]
   ) => {
-    if (entity.miniplex.world !== this) {
+    if (entity.__miniplex.world !== this) {
       throw `Tried to remove ${components} from an entity that is not managed by this world.`
     }
 
@@ -205,7 +205,7 @@ export class World<T extends IEntity = UntypedEntity> {
       return entity
     },
 
-    destroyEntity: (entity: RegisteredEntity<T>) => {
+    destroyEntity: (entity: RegisteredEntity<T> | T) => {
       this.queuedCommands.add(() => this.destroyEntity(entity))
     },
 

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -103,10 +103,10 @@ describe("World", () => {
         expect(world.entities.length).toEqual(1)
       })
 
-      it("does not yet assign the internal component", () => {
+      it("returns nothing", () => {
         const world = new World<Entity>()
-        const entity = world.queue.createEntity({ name: "Alice" })
-        expect(entity.__miniplex).toBeUndefined()
+        const result = world.queue.createEntity({ name: "Alice" })
+        expect(result).toBeUndefined()
       })
     })
   })

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -28,7 +28,7 @@ describe("World", () => {
     it("creates a new entity", () => {
       const world = new World<Entity>()
       const entity = world.createEntity()
-      expect(entity.miniplex.id).not.toBeUndefined()
+      expect(entity.__miniplex.id).not.toBeUndefined()
     })
 
     it("accepts an object that will become the entity", () => {
@@ -48,20 +48,20 @@ describe("World", () => {
     it("assigns an ID to the entity's miniplex component", () => {
       const world = new World<Entity>()
       const entity = world.createEntity({ name: "Alice" })
-      expect(entity.miniplex.id).toEqual(1)
+      expect(entity.__miniplex.id).toEqual(1)
     })
 
     it("assigns a reference to the world to the entity's miniplex component", () => {
       const world = new World<Entity>()
       const entity = world.createEntity({ name: "Alice" })
-      expect(entity.miniplex.world).toEqual(world)
+      expect(entity.__miniplex.world).toEqual(world)
     })
 
     it("assigns automatically incrementing IDs", () => {
       const world = new World<Entity>()
       world.createEntity({ name: "Alice" })
       const entity = world.createEntity({ name: "Bob" })
-      expect(entity.miniplex.id).toEqual(2)
+      expect(entity.__miniplex.id).toEqual(2)
     })
 
     describe(".queued", () => {
@@ -77,11 +77,11 @@ describe("World", () => {
       it("does not yet assign an ID", () => {
         const world = new World<Entity>()
         const entity = world.queue.createEntity({ name: "Alice" })
-        expect(entity.miniplex).toBeUndefined()
+        expect(entity.__miniplex).toBeUndefined()
 
         /* Flushing won't change the ID */
         world.queue.flush()
-        expect(entity.miniplex!.id).toEqual(1)
+        expect(entity.__miniplex!.id).toEqual(1)
       })
     })
   })
@@ -145,7 +145,7 @@ describe("World", () => {
       world.addComponent(entity, { ...position(1, 2), ...health(100) })
 
       expect(entity).toEqual({
-        miniplex: { id: 1, world, archetypes: [] },
+        __miniplex: { id: 1, world, archetypes: [] },
         position: { x: 1, y: 2 },
         health: { max: 100, current: 100 }
       })
@@ -158,7 +158,7 @@ describe("World", () => {
       world.addComponent(entity, position(1, 2), health(100))
 
       expect(entity).toEqual({
-        miniplex: { id: 1, world, archetypes: [] },
+        __miniplex: { id: 1, world, archetypes: [] },
         position: { x: 1, y: 2 },
         health: { max: 100, current: 100 }
       })

--- a/packages/miniplex/test/id.test.ts
+++ b/packages/miniplex/test/id.test.ts
@@ -49,7 +49,7 @@ describe("adding IDs to entities", () => {
     })
 
     const world = new World<EntityWithNumericalId>()
-    const entity = world.createEntity({ ...id(), ...name("Alice") })
+    const entity = world.createEntity(id(), name("Alice"))
 
     expect(entity.id).toEqual(1)
   })

--- a/packages/miniplex/test/id.test.ts
+++ b/packages/miniplex/test/id.test.ts
@@ -1,0 +1,64 @@
+/*
+
+Just a bunch of different usage scenarios around (optional) entity ID generation.
+
+*/
+
+import { v4 as uuidv4 } from "uuid"
+import { World } from "../src"
+
+type NumericalIDComponent = {
+  id: number
+}
+
+type UUIDComponent = {
+  id: string
+}
+
+type NameComponent = {
+  name: string
+}
+
+const numericalIdGenerator = (start = 1) => {
+  let nextId = start
+  return () => nextId++
+}
+
+type EntityWithNumericalId = NumericalIDComponent & Partial<NameComponent>
+type EntityWithUUID = UUIDComponent & Partial<NameComponent>
+
+describe("adding IDs to entities", () => {
+  it("can be done using a simple ID generator", () => {
+    const nextId = numericalIdGenerator()
+
+    const world = new World<EntityWithNumericalId>()
+    const entity = world.createEntity({ id: nextId(), name: "Alice" })
+
+    expect(entity.id).toEqual(1)
+  })
+
+  it("can be done using a component factory", () => {
+    const nextId = numericalIdGenerator()
+
+    const id = (): NumericalIDComponent => ({
+      id: nextId()
+    })
+
+    const name = (name: string): NameComponent => ({
+      name
+    })
+
+    const world = new World<EntityWithNumericalId>()
+    const entity = world.createEntity({ ...id(), ...name("Alice") })
+
+    expect(entity.id).toEqual(1)
+  })
+
+  it("also works with UUIds", () => {
+    const world = new World<EntityWithUUID>()
+    const entity = world.createEntity({ id: uuidv4(), name: "Alice" })
+    expect(entity.id).toMatch(
+      /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,6 +1926,11 @@
   dependencies:
     "@types/jest" "*"
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -5880,6 +5885,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.1.1:
   version "2.3.0"


### PR DESCRIPTION
- make the intent clearer (the stuff inside is internal!)
- moves the consumer-facing ID concern into userland (which means a little more work if your project has been making use of the automatically generated IDs, but also makes things a lot more flexible since a lot of projects might have an opinion on whether or not they need IDs, and what they should look like)

Checklist:

- [x] Implement the change
- [x] Adapt documentation
- [x] Add an example for auto-generating IDs to the README and the changeset
- [x] Make `queue.createEntity` return void
- [x] ~Maybe provide a simple auto-incrementing ID generator in the library to make things as easy as possible for existing users (hi Jörg)~ -- the library doesn't provide one, but the documentation includes examples.