### PR TITLE
Mutate created entities

### DIFF
--- a/.changeset/chilled-adults-guess.md
+++ b/.changeset/chilled-adults-guess.md
@@ -1,0 +1,5 @@
+---
+"miniplex": minor
+---
+
+**Breaking Change:** `createEntity` will now, like in earlier versions of this library, mutate the first argument that is passed into it (and return it). This allows for patterns where you create the actual entity _object_ before you actually convert it into an entity through _createEntity_.

--- a/.changeset/tidy-rules-allow.md
+++ b/.changeset/tidy-rules-allow.md
@@ -1,0 +1,5 @@
+---
+"miniplex-react": minor
+---
+
+**New:** `useEntities` is a new hook that will create and return a specified number of entities, initialized through an optional entity factory. `useEntity` does the same, but just for a single entity.

--- a/packages/miniplex-react/src/createECS.tsx
+++ b/packages/miniplex-react/src/createECS.tsx
@@ -125,13 +125,6 @@ export function createECS<TEntity extends IEntity = UntypedEntity>() {
   }
 
   /**
-   * Return the current entity context.
-   */
-  function useEntity() {
-    return useContext(EntityContext)
-  }
-
-  /**
    * Declaratively add a component to an entity.
    */
   function Component<K extends keyof TEntity, V = TEntity[K]>({
@@ -143,7 +136,7 @@ export function createECS<TEntity extends IEntity = UntypedEntity>() {
     data?: V
     children?: ReactElement | ((entity: TEntity) => ReactElement)
   }) {
-    const entity = useEntity()
+    const entity = useContext(EntityContext)
     const ref = useRef<TEntity[K]>(null!)
 
     /* Warn the user that passing multiple children is not allowed. */
@@ -170,6 +163,17 @@ export function createECS<TEntity extends IEntity = UntypedEntity>() {
           )}
       </>
     )
+  }
+
+  function useEntity(entityFn: () => TEntity) {
+    const entity = useConst<TEntity>(entityFn)
+
+    useEffect(() => {
+      const registeredEntity = world.createEntity(entity)
+      return () => world.destroyEntity(registeredEntity)
+    }, [])
+
+    return entity
   }
 
   /**

--- a/packages/miniplex-react/src/createECS.tsx
+++ b/packages/miniplex-react/src/createECS.tsx
@@ -176,6 +176,32 @@ export function createECS<TEntity extends IEntity = UntypedEntity>() {
     return entity
   }
 
+  function useEntities(count: number, entityFn: () => TEntity) {
+    /* Create entity objects */
+    const entities = useConst(() => {
+      const entities = []
+      for (let i = 0; i < count; i++) {
+        entities.push(entityFn())
+      }
+      return entities
+    })
+
+    /* Create/Destroy entities */
+    useEffect(() => {
+      for (const entity of entities) {
+        world.createEntity(entity)
+      }
+
+      return () => {
+        for (const entity of entities) {
+          world.destroyEntity(entity as RegisteredEntity<TEntity>)
+        }
+      }
+    })
+
+    return entities
+  }
+
   /**
    * Return the entities of the specified archetype and subscribe this component
    * to it, making it re-render when entities are added to or removed from it.
@@ -205,6 +231,7 @@ export function createECS<TEntity extends IEntity = UntypedEntity>() {
     world,
     useArchetype,
     useEntity,
+    useEntities,
     Entity,
     Component,
     MemoizedEntity,

--- a/packages/miniplex-react/src/createECS.tsx
+++ b/packages/miniplex-react/src/createECS.tsx
@@ -165,23 +165,16 @@ export function createECS<TEntity extends IEntity = UntypedEntity>() {
     )
   }
 
-  function useEntity(entityFn: () => TEntity) {
-    const entity = useConst<TEntity>(entityFn)
-
-    useEffect(() => {
-      const registeredEntity = world.createEntity(entity)
-      return () => world.destroyEntity(registeredEntity)
-    }, [])
-
-    return entity
-  }
-
-  function useEntities(count: number, entityFn: () => TEntity) {
+  /**
+   * Create a number of entities, defined through an optional entity factory,
+   * and add/remove them to/from the world on mount/unmount.
+   */
+  function useEntities(count: number, entityFactory?: () => TEntity) {
     /* Create entity objects */
     const entities = useConst(() => {
       const entities = []
       for (let i = 0; i < count; i++) {
-        entities.push(entityFn())
+        entities.push(entityFactory?.())
       }
       return entities
     })
@@ -200,6 +193,13 @@ export function createECS<TEntity extends IEntity = UntypedEntity>() {
     })
 
     return entities
+  }
+
+  /**
+   * Return a single entity and automatically add/remove it to/from the world.
+   */
+  function useEntity(entityFn?: () => TEntity) {
+    return useEntities(1, entityFn)[0]
   }
 
   /**

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -117,6 +117,11 @@ export class World<T extends IEntity = UntypedEntity> {
     return entity as RegisteredEntity<T>
   }
 
+  private unregisterEntity = (entity: RegisteredEntity<T>) => {
+    delete (entity as T).__miniplex
+    return entity as T
+  }
+
   public createEntity = <P>(
     entity: T = {} as T,
     ...extraComponents: Partial<T>[]
@@ -138,7 +143,7 @@ export class World<T extends IEntity = UntypedEntity> {
     return registeredEntity
   }
 
-  public destroyEntity = (entity: RegisteredEntity<T> | T) => {
+  public destroyEntity = (entity: RegisteredEntity<T>) => {
     if (entity.__miniplex?.world !== this) return
 
     /* Remove it from our global list of entities */
@@ -151,7 +156,7 @@ export class World<T extends IEntity = UntypedEntity> {
     }
 
     /* Remove its miniplex component */
-    delete (entity as T).__miniplex
+    this.unregisterEntity(entity)
   }
 
   public addComponent = (

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -105,34 +105,37 @@ export class World<T extends IEntity = UntypedEntity> {
 
   /* MUTATION FUNCTIONS */
 
-  public createEntity = <P>(
-    base: T = {} as T,
-    ...extraComponents: Partial<T>[]
-  ): RegisteredEntity<T> => {
-    /* Merge all given partials into a single object. */
-    const mergedExtraComponents = extraComponents.reduce(
-      (acc, partial) => ({ ...acc, ...partial }),
-      {} as T
-    )
-
-    /* Create the entity. */
-    const entity = {
-      ...base,
-      ...mergedExtraComponents,
+  private registerEntity = (entity: T) => {
+    Object.assign(entity, {
       __miniplex: {
         id: this.nextId(),
         world: this,
         archetypes: []
       }
+    })
+
+    return entity as RegisteredEntity<T>
+  }
+
+  public createEntity = <P>(
+    entity: T = {} as T,
+    ...extraComponents: Partial<T>[]
+  ): RegisteredEntity<T> => {
+    /* Mix in extra components into entity. */
+    for (const extra of extraComponents) {
+      Object.assign(entity, extra)
     }
 
+    /* Mix in internal component into entity. */
+    const registeredEntity = this.registerEntity(entity)
+
     /* Store the entity... */
-    this.entities.push(entity)
+    this.entities.push(registeredEntity)
 
     /* ...and add it to relevant indices. */
-    this.indexEntity(entity)
+    this.indexEntity(registeredEntity)
 
-    return entity
+    return registeredEntity
   }
 
   public destroyEntity = (entity: RegisteredEntity<T> | T) => {

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -37,11 +37,11 @@ describe("World", () => {
       expect(entity).toMatchObject({ name: "Alice" })
     })
 
-    it("returns a new object", () => {
+    it("mutates and returns the same new object", () => {
       const world = new World<Entity>()
       const entity: Partial<Entity> = { name: "Alice" }
       const returnedEntity = world.createEntity(entity)
-      expect(returnedEntity).not.toBe(entity)
+      expect(returnedEntity).toBe(entity)
     })
 
     it("accepts multiple partial entities that are merged into the same entity object", () => {

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -145,6 +145,14 @@ describe("World", () => {
       world.destroyEntity(entity)
       expect(withVelocity.entities).not.toContain(entity)
     })
+
+    it("removes the internal Miniplex component", () => {
+      const world = new World<GameObject>()
+      const entity = world.createEntity({ position: { x: 0, y: 0 } })
+      expect(entity).toHaveProperty("__miniplex")
+      world.destroyEntity(entity)
+      expect(entity).not.toHaveProperty("__miniplex")
+    })
   })
 
   describe("addComponent", () => {


### PR DESCRIPTION
- Once again have `createEntity` mutate the entity passed into it (instead of creating a new object.) This allows a very neat implementation of the new `useEntity` hook that will immediately create and return the entity object, but only actually add it to and remove it from the world through an effect.
- New `useEntity` hook :-)