### PR TITLE
Archetype.first - returns first entity in archetype

### DIFF
--- a/.changeset/olive-oranges-compare.md
+++ b/.changeset/olive-oranges-compare.md
@@ -1,0 +1,14 @@
+---
+"miniplex": patch
+---
+
+**New:** Archetypes now expose a `first` getter that returns the first of the entities in the archetype (or `null` if it doesn't have any entities.) This streamlines situations where you deal with singleton entities (like a player, camera, and so on.) For example, in `miniplex-react`, you can now do the following:
+
+```tsx
+export const CameraRigSystem: FC = () => {
+  const player = ECS.useArchetype("isPlayer").first
+  const camera = ECS.useArchetype("isCamera").first
+
+  /* Do things with player and camera */
+}
+```

--- a/packages/miniplex/src/Archetype.ts
+++ b/packages/miniplex/src/Archetype.ts
@@ -17,6 +17,11 @@ export class Archetype<
     EntityWith<RegisteredEntity<TEntity>, TQuery[number]>
   >()
 
+  /** Returns the first entity within this archetype. */
+  get first() {
+    return this.entities[0] || null
+  }
+
   /** Listeners on this event are invoked when an entity is added to this archetype's index. */
   public onEntityAdded = new Signal<RegisteredEntity<TEntity>>()
 

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -350,5 +350,20 @@ describe("World", () => {
       expect(withAdmin.entities).toEqual([])
       expect(withName.entities).toEqual([bob])
     })
+
+    describe("Archetype.first", () => {
+      it("returns the first entity when the archetype has entities", () => {
+        const { world, alice, bob } = setup()
+        const withAdmin = world.archetype("admin")
+        expect(withAdmin.first).toBe(alice)
+      })
+
+      it("returns null when the archetype has no entities", () => {
+        const { world, alice, bob } = setup()
+        const withAdmin = world.archetype("admin")
+        world.removeComponent(alice, "admin")
+        expect(withAdmin.first).toEqual(null)
+      })
+    })
   })
 })


### PR DESCRIPTION
Sometimes you have singleton entities (like the player, or a camera), and this helps clean up the code around these a little. Example:

```tsx
export const CameraRigSystem: FC = () => {
  const player = ECS.useArchetype("isPlayer").first
  const camera = ECS.useArchetype("isCamera").first

  /* ... */
}
```