### PR TITLE
Keep archetypes around when clearing the world, but empty them

### DIFF
--- a/.changeset/sour-nails-repair.md
+++ b/.changeset/sour-nails-repair.md
@@ -1,0 +1,5 @@
+---
+"miniplex": patch
+---
+
+**Fixed:** When the world is cleared, archetypes now also get their entities lists cleared.

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -236,8 +236,10 @@ export class World<T extends IEntity = UntypedEntity> {
     /* Remove all entities */
     this.entities.length = 0
 
-    /* Remove all archetype indices */
-    this.archetypes.clear()
+    /* Remove all entities from all archetypes, but keep them around in case they are referenced */
+    for (const archetype of this.archetypes.values()) {
+      archetype.entities.length = 0
+    }
 
     /* Clear queue */
     this.queuedCommands.clear()

--- a/packages/miniplex/test/World.test.ts
+++ b/packages/miniplex/test/World.test.ts
@@ -351,6 +351,18 @@ describe("World", () => {
       expect(withName.entities).toEqual([bob])
     })
 
+    it("when world is cleared, archetypes remain intact but have entities removed", () => {
+      const { world, alice, bob } = setup()
+      const withAdmin = world.archetype("admin")
+      expect(withAdmin.entities.length).toEqual(1)
+
+      world.clear()
+      expect(withAdmin.entities.length).toEqual(0)
+
+      world.createEntity({ name: "Alice 2.0", admin: true })
+      expect(withAdmin.entities.length).toEqual(1)
+    })
+
     describe("Archetype.first", () => {
       it("returns the first entity when the archetype has entities", () => {
         const { world, alice, bob } = setup()


### PR DESCRIPTION
Resolves https://github.com/hmans/miniplex/issues/83