### PR TITLE
Stronger typing for Archetype

### DIFF
--- a/.changeset/cold-monkeys-thank.md
+++ b/.changeset/cold-monkeys-thank.md
@@ -1,0 +1,5 @@
+---
+"miniplex": patch
+---
+
+Typing improvements, thanks to @benwest.

--- a/packages/miniplex/src/Archetype.ts
+++ b/packages/miniplex/src/Archetype.ts
@@ -8,22 +8,29 @@ import { ComponentName, EntityWith, IEntity } from "./World"
  */
 export type Query<T extends IEntity> = ComponentName<T>[]
 
+export type ArchetypeEntity<
+  TEntity extends IEntity,
+  TQuery extends Query<TEntity> = Query<TEntity>
+> = EntityWith<TEntity, TQuery[number]>
+
 export class Archetype<
   TEntity extends IEntity,
   TQuery extends Query<TEntity> = Query<TEntity>
 > {
   /** A list of entities belonging to this archetype. */
   public entities = new Array<
-    EntityWith<RegisteredEntity<TEntity>, TQuery[number]>
+    ArchetypeEntity<RegisteredEntity<TEntity>, TQuery>
   >()
 
   /** Returns the first entity within this archetype. */
-  get first() {
+  get first(): ArchetypeEntity<RegisteredEntity<TEntity>, TQuery> | null {
     return this.entities[0] || null
   }
 
   /** Listeners on this event are invoked when an entity is added to this archetype's index. */
-  public onEntityAdded = new Signal<RegisteredEntity<TEntity>>()
+  public onEntityAdded = new Signal<
+    ArchetypeEntity<RegisteredEntity<TEntity>, TQuery>
+  >()
 
   /** Listeners on this event are invoked when an entity is removed from this archetype's index. */
   public onEntityRemoved = new Signal<RegisteredEntity<TEntity>>()
@@ -40,7 +47,7 @@ export class Archetype<
     /* If the entity should be indexed, but isn't, add it. */
     if (shouldBeIndexed && !isIndexed) {
       entity.__miniplex.archetypes.push(this)
-      this.entities.push(entity as any)
+      this.entities.push(entity)
       this.onEntityAdded.emit(entity)
       return
     }

--- a/packages/miniplex/src/util/entityIsArchetype.ts
+++ b/packages/miniplex/src/util/entityIsArchetype.ts
@@ -1,6 +1,9 @@
-import { Query } from "../Archetype"
+import { Query, ArchetypeEntity } from "../Archetype"
 import { IEntity } from "../World"
 
-export function entityIsArchetype<T extends IEntity>(entity: T, query: Query<T>) {
+export function entityIsArchetype<
+  TEntity extends IEntity,
+  TQuery extends Query<TEntity>
+>(entity: TEntity, query: TQuery): entity is ArchetypeEntity<TEntity, TQuery> {
   return query.every((name) => name in entity)
 }


### PR DESCRIPTION
Hello, I'm playing around with this library for a game project and enjoying it so far ✌️. I ran into a few hiccups with the typings for Archetype and I think these changes make sense - let me know if I misunderstood something.

– Entities emitted by `onEntityAdded` can have their type narrowed by the query
– But I think those in `onEntityRemoved` can't, because they may have been removed for no longer matching the query?
– `first` can return null, but the inferred type didn't know that
– and I also added an assertion to `entityIsArchetype` so `Archetype.indexEntity` no longer needs to use `any`.