### PR TITLE
add Archetype[Symbol.iterator]

### DIFF
--- a/.changeset/thick-trees-know.md
+++ b/.changeset/thick-trees-know.md
@@ -1,0 +1,13 @@
+---
+"miniplex": patch
+---
+
+**Added:** Archtypes now implement a `[Symbol.iterator]`, meaning they can be iterated over directly:
+
+```js
+const withVelocity = world.archetype("velocity")
+
+for (const { velocity } of withVelocity) {
+   /* ... */
+}
+```

--- a/packages/miniplex/src/Archetype.ts
+++ b/packages/miniplex/src/Archetype.ts
@@ -17,6 +17,10 @@ export class Archetype<
     EntityWith<RegisteredEntity<TEntity>, TQuery[number]>
   >()
 
+  get [Symbol.iterator]() {
+    return this.entities[Symbol.iterator]
+  }
+
   /** Returns the first entity within this archetype. */
   get first() {
     return this.entities[0] || null


### PR DESCRIPTION
I thought it was nice to allow iterating of Archetype directly - it sometimes feels natural to call an archetype `entities`, but then you have to write `entities.entities`

```ts
const entities = world.archetype("doot")

for (const { doot } of entities) {
   
}
```