### PR TITLE
Compact Entities

### DIFF
--- a/.changeset/many-dryers-yawn.md
+++ b/.changeset/many-dryers-yawn.md
@@ -1,0 +1,10 @@
+---
+"miniplex": minor
+---
+
+**Breaking Change:** When destroying entities, they are now removed from the world's global list of entities as well as the archetypes' lists of entities using the shuffle-and-pop pattern. This has the following side-effects that _may_ impact your code:
+
+- Entities are no longer guaranteed to stay in the same order.
+- The entity ID storied in its internal `__miniplex` component no longer corresponds to its index in the `entities` array.
+
+This change provides significantly improved performance in situations where a large number of entities are continuously being created and destroyed.

--- a/packages/miniplex/README.md
+++ b/packages/miniplex/README.md
@@ -103,7 +103,7 @@ world.addComponent(entity, { velocity: { x: 10, y: 0, z: 0 } })
 
 Now the entity has two components: `position` and `velocity`.
 
-**Note:** Once added to the world, entities also automatically receive an internal `__miniplex` component. This component contains data that helps Miniplex track the entity's lifecycle, and optimize a lot of interactions with the world, and you can safely ignore it.
+> **Note** Once added to the world, entities also automatically receive an internal `__miniplex` component. This component contains data that helps Miniplex track the entity's lifecycle, and optimize a lot of interactions with the world, and you can safely ignore it.
 
 ### Querying Entities
 
@@ -160,6 +160,10 @@ world.queue.flush()
 **Note:** Please remember that the queue is not flushed automatically, and doing this is left to you. You might, for example, do this in your game's main loop, after all systems have finished executing.
 
 ## Usage Hints
+
+### Do not add or remove entity properties directly
+
+Since entities are just normal objects, you might be tempted to just add new properties to (or delete properties from) them directly. **This is a bad idea** because it will skip the indexing step needed to make sure the entity is listed in the correct archetypes. Please always go through `addComponent` and `removeComponent`!
 
 ### Consider using Component Factories
 

--- a/packages/miniplex/src/Archetype.ts
+++ b/packages/miniplex/src/Archetype.ts
@@ -1,6 +1,7 @@
 import { Signal } from "@hmans/signal"
 import { RegisteredEntity } from "."
 import { entityIsArchetype } from "./util/entityIsArchetype"
+import { removeFromList } from "./util/removeFromList"
 import { ComponentName, EntityWith, IEntity } from "./World"
 
 /**
@@ -51,10 +52,9 @@ export class Archetype<E extends IEntity, Q extends Query<E> = Query<E>> {
 
     /* If the entity should not be indexed, but is, let's remove it. */
     if (!shouldBeIndexed && isIndexed) {
-      this.entities.splice(this.entities.indexOf(entity as any, 0), 1)
+      removeFromList(this.entities, entity)
       this.onEntityRemoved.emit(entity)
-      const apos = entity.__miniplex.archetypes.indexOf(this, 0)
-      entity.__miniplex.archetypes.splice(apos, 1)
+      removeFromList(entity.__miniplex.archetypes, this)
       return
     }
   }

--- a/packages/miniplex/src/Archetype.ts
+++ b/packages/miniplex/src/Archetype.ts
@@ -52,18 +52,14 @@ export class Archetype<E extends IEntity, Q extends Query<E> = Query<E>> {
 
     /* If the entity should not be indexed, but is, let's remove it. */
     if (!shouldBeIndexed && isIndexed) {
-      removeFromList(this.entities, entity)
-      this.onEntityRemoved.emit(entity)
-      removeFromList(entity.__miniplex.archetypes, this)
+      this.removeEntity(entity)
       return
     }
   }
 
   public removeEntity(entity: RegisteredEntity<E>) {
-    const pos = this.entities.indexOf(entity as any, 0)
-    if (pos >= 0) {
-      this.entities.splice(pos, 1)
-      this.onEntityRemoved.emit(entity)
-    }
+    removeFromList(this.entities, entity)
+    removeFromList(entity.__miniplex.archetypes, this)
+    this.onEntityRemoved.emit(entity)
   }
 }

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -126,7 +126,9 @@ export class World<T extends IEntity = UntypedEntity> {
     if (entity.__miniplex?.world !== this) return
 
     /* Remove it from our global list of entities */
-    this.entities[entity.__miniplex.id] = null
+    const pos = this.entities.indexOf(entity)
+    this.entities[pos] = this.entities[this.entities.length - 1]
+    this.entities.pop()
 
     /* Remove entity from all archetypes */
     for (const archetype of entity.__miniplex.archetypes) {

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -130,7 +130,8 @@ export class World<T extends IEntity = UntypedEntity> {
     removeFromList(this.entities, entity)
 
     /* Remove entity from all archetypes */
-    for (const archetype of entity.__miniplex.archetypes) {
+    for (let i = entity.__miniplex.archetypes.length - 1; i >= 0; i--) {
+      const archetype = entity.__miniplex.archetypes[i]
       archetype.removeEntity(entity)
     }
 

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -84,7 +84,7 @@ export class World<T extends IEntity = UntypedEntity> {
 
     /* ...and refresh the indexing of all our entities. */
     for (const entity of this.entities) {
-      if (entity) archetype.indexEntity(entity)
+      archetype.indexEntity(entity)
     }
 
     return archetype as Archetype<T, TQuery>

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -60,6 +60,9 @@ export class World<T extends IEntity = UntypedEntity> {
   /** An array holding all entities known to this world. */
   private entities = new Array<RegisteredEntity<T> | null>()
 
+  /** The ID assigned to the next entity. */
+  private nextId = 0
+
   /** A list of known archetypes. */
   private archetypes = new Map<string, Archetype<T>>()
 
@@ -104,7 +107,7 @@ export class World<T extends IEntity = UntypedEntity> {
     /* Mix in internal component into entity. */
     const registeredEntity = Object.assign(entity, {
       __miniplex: {
-        id: this.entities.length,
+        id: this.nextId++,
         world: this,
         archetypes: []
       }

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -58,7 +58,7 @@ export type Tag = true
 
 export class World<T extends IEntity = UntypedEntity> {
   /** An array holding all entities known to this world. */
-  public entities = new Array<RegisteredEntity<T> | null>()
+  private entities = new Array<RegisteredEntity<T> | null>()
 
   /** A list of known archetypes. */
   private archetypes = new Map<string, Archetype<T>>()

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -59,7 +59,7 @@ export type Tag = true
 
 export class World<T extends IEntity = UntypedEntity> {
   /** An array holding all entities known to this world. */
-  private entities = new Array<RegisteredEntity<T> | null>()
+  public entities = new Array<RegisteredEntity<T>>()
 
   /** The ID assigned to the next entity. */
   private nextId = 0

--- a/packages/miniplex/src/World.ts
+++ b/packages/miniplex/src/World.ts
@@ -1,6 +1,7 @@
 import { Archetype, Query } from "./Archetype"
 import { commandQueue } from "./util/commandQueue"
 import { normalizeQuery } from "./util/normalizeQuery"
+import { removeFromList } from "./util/removeFromList"
 import { WithRequiredKeys } from "./util/types"
 
 /**
@@ -126,9 +127,7 @@ export class World<T extends IEntity = UntypedEntity> {
     if (entity.__miniplex?.world !== this) return
 
     /* Remove it from our global list of entities */
-    const pos = this.entities.indexOf(entity)
-    this.entities[pos] = this.entities[this.entities.length - 1]
-    this.entities.pop()
+    removeFromList(this.entities, entity)
 
     /* Remove entity from all archetypes */
     for (const archetype of entity.__miniplex.archetypes) {

--- a/packages/miniplex/src/util/removeFromList.ts
+++ b/packages/miniplex/src/util/removeFromList.ts
@@ -1,0 +1,8 @@
+export function removeFromList<T>(list: T[], item: T) {
+  const pos = list.indexOf(item, 0)
+
+  if (pos >= 0) {
+    list[pos] = list[list.length - 1]
+    list.pop()
+  }
+}


### PR DESCRIPTION
- When an entity is destroyed, it is now removed using the shift + pop method. This is faster than `splice` in a lot of situations and also helps with issues like #92.
- This has the side-effect of entities within the `entities` list now no longer being in a guaranteed order.
- Also, entity IDs no longer represent the entity's position in the array (but you shouldn't have been using them that way, anyway! 🤡 )
- But it also has the nice side-effect of `entities` no longer containing `null` entries!