### PR TITLE
Don't remove and re-add component on re-renders

### DIFF
--- a/.changeset/sixty-donkeys-walk.md
+++ b/.changeset/sixty-donkeys-walk.md
@@ -1,0 +1,5 @@
+---
+"miniplex-react": patch
+---
+
+**Fixed:** When `<Component>` re-renders, it is expected to update the component's data to the value of its `data` prop, or the `ref` of its React child. It has so far been doing that by removing and re-adding the entire component, which had the side-effect of making the entity disappear from and then reappear in archetypes indexing that component. This has now been fixed; the component will only be added and removed once (at the beginning and the end of the React component's lifetime, respectively); in re-renders during its lifetime, the data will simply be updated directly when a change is detected. This allows you to connect a `<Component>` to the usual reactive mechanisms in React.

--- a/.changeset/sixty-donkeys-walk.md
+++ b/.changeset/sixty-donkeys-walk.md
@@ -2,4 +2,6 @@
 "miniplex-react": patch
 ---
 
-**Fixed:** When `<Component>` re-renders, it is expected to update the component's data to the value of its `data` prop, or the `ref` of its React child. It has so far been doing that by removing and re-adding the entire component, which had the side-effect of making the entity disappear from and then reappear in archetypes indexing that component. This has now been fixed; the component will only be added and removed once (at the beginning and the end of the React component's lifetime, respectively); in re-renders during its lifetime, the data will simply be updated directly when a change is detected. This allows you to connect a `<Component>` to the usual reactive mechanisms in React.
+**Fixed:** When `<Component>` re-renders, it is expected to reactively update the component's data to the value of its `data` prop, or the `ref` of its React child. It has so far been doing that by removing and re-adding the entire component, which had the side-effect of making the entity disappear from and then reappear in archetypes indexing that component. This has now been fixed.
+
+The component will only be added and removed once (at the beginning and the end of the React component's lifetime, respectively); in re-renders during its lifetime, the data will simply be updated directly when a change is detected. This allows you to connect a `<Component>` to the usual reactive mechanisms in React.

--- a/packages/miniplex-react/src/createECS.tsx
+++ b/packages/miniplex-react/src/createECS.tsx
@@ -174,6 +174,7 @@ export function createECS<Entity extends IEntity = UntypedEntity>(
       throw new Error("<Component> will only accept a single React child.")
     }
 
+    /* Add (and remove) the component on mount/unmount. */
     useIsomorphicLayoutEffect(() => {
       world.addComponent(entity, name, data ?? (ref.current as any))
 
@@ -182,7 +183,12 @@ export function createECS<Entity extends IEntity = UntypedEntity>(
           world.removeComponent(entity, name)
         }
       }
-    }, [entity, name, data])
+    }, [entity, name])
+
+    /* On regular re-renders of this component, update the component data. */
+    useIsomorphicLayoutEffect(() => {
+      Object.assign(entity, { [name]: data ?? (ref.current as any) })
+    }, [entity, data])
 
     /* If no children are passed, we're done. */
     if (!children) return null

--- a/packages/miniplex-react/test/createECS.test.tsx
+++ b/packages/miniplex-react/test/createECS.test.tsx
@@ -1,9 +1,9 @@
 import "@testing-library/jest-dom"
 import { render, screen } from "@testing-library/react"
-import { act } from "react-dom/test-utils"
 import { RegisteredEntity, Tag, World } from "miniplex"
+import { createRef } from "react"
+import { act } from "react-dom/test-utils"
 import { createECS } from "../src/createECS"
-import { createRef, useLayoutEffect, useState } from "react"
 
 type Entity = { name: string; age?: number }
 

--- a/packages/miniplex-react/test/createECS.test.tsx
+++ b/packages/miniplex-react/test/createECS.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react"
 import { act } from "react-dom/test-utils"
 import { RegisteredEntity, Tag, World } from "miniplex"
 import { createECS } from "../src/createECS"
-import { createRef } from "react"
+import { createRef, useLayoutEffect, useState } from "react"
 
 type Entity = { name: string; age?: number }
 
@@ -68,6 +68,23 @@ describe("createECS", () => {
       )
 
       expect(alice.admin).toEqual(true)
+    })
+
+    it("updates the component reactively", () => {
+      const { world, Entity, Component } = createECS<{ count?: number }>()
+      const alice = world.createEntity({})
+
+      const Test = ({ count = 0 }) => (
+        <Entity entity={alice}>
+          <Component name="count" data={count} />
+        </Entity>
+      )
+
+      const { rerender } = render(<Test count={0} />)
+      expect(alice.count).toEqual(0)
+
+      rerender(<Test count={1} />)
+      expect(alice.count).toEqual(1)
     })
 
     it("it accepts a single React child to set as the entity's data", () => {

--- a/packages/miniplex-react/test/createECS.test.tsx
+++ b/packages/miniplex-react/test/createECS.test.tsx
@@ -74,6 +74,11 @@ describe("createECS", () => {
       const { world, Entity, Component } = createECS<{ count?: number }>()
       const alice = world.createEntity({})
 
+      /* Set up an archetype callback that we use to check if the entity is being re-added or not */
+      let callbacks = 0
+      const withCount = world.archetype("count")
+      withCount.onEntityAdded.add(() => callbacks++)
+
       const Test = ({ count = 0 }) => (
         <Entity entity={alice}>
           <Component name="count" data={count} />
@@ -82,9 +87,11 @@ describe("createECS", () => {
 
       const { rerender } = render(<Test count={0} />)
       expect(alice.count).toEqual(0)
+      expect(callbacks).toEqual(1)
 
       rerender(<Test count={1} />)
       expect(alice.count).toEqual(1)
+      expect(callbacks).toEqual(1) /* The entity should not be re-added */
     })
 
     it("it accepts a single React child to set as the entity's data", () => {


### PR DESCRIPTION
This fixes the issue described in #172, where an instance of `<Component>` being re-rendered will remove and re-add the given component, causing the entity to be needlessly removed and re-added to related archetype indices.

The change implemented here makes sure that the component will only be added and removed at the beginning and end of the React component's lifetime. On normal re-renders, the component _data_ will simply be updated, if the `data` prop has changed. (The user should take care that object values are properly memoized.)