### PR TITLE
`id` & `get`

### DIFF
--- a/packages/miniplex-core/src/ids.ts
+++ b/packages/miniplex-core/src/ids.ts
@@ -1,10 +1,18 @@
 import { IEntity } from "./types"
 
 const entityToId = new WeakMap<IEntity, number>()
+const idToEntity = new Map<number, IEntity>()
 
 let nextId = 0
 
 export const id = (entity: IEntity) => {
-  if (!entityToId.has(entity)) entityToId.set(entity, nextId++)
-  return entityToId.get(entity)
+  if (!entityToId.has(entity)) {
+    entityToId.set(entity, nextId)
+    idToEntity.set(nextId, entity)
+    return nextId++
+  }
+
+  return entityToId.get(entity)!
 }
+
+export const get = (id: number) => idToEntity.get(id)

--- a/packages/miniplex-core/src/ids.ts
+++ b/packages/miniplex-core/src/ids.ts
@@ -1,5 +1,12 @@
 import { IEntity } from "./types"
 
+/*
+FIXME: the following has the problem that even though we are only tracking
+entities through a WeakMap, we are keeping references to entities for all time
+in a normal Map, meaning that they will never get garbage collected. We need a
+way to unregister entities. Maybe `World` can do it for us?
+*/
+
 const entityToId = new WeakMap<IEntity, number>()
 const idToEntity = new Map<number, IEntity>()
 

--- a/packages/miniplex-core/test/Bucket.test.ts
+++ b/packages/miniplex-core/test/Bucket.test.ts
@@ -304,21 +304,3 @@ describe("Symbol.iterator", () => {
     expect(bucket.entities).toEqual([])
   })
 })
-
-describe("id", () => {
-  it("returns a numerical ID for the specified entity", () => {
-    const entity = {}
-    expect(id(entity)).toBe(0)
-  })
-
-  it("returns the same ID for the same entity", () => {
-    const entity = {}
-    expect(id(entity)).toBe(id(entity))
-  })
-
-  it("returns a different ID for different entities", () => {
-    const entity1 = {}
-    const entity2 = {}
-    expect(id(entity1)).not.toBe(id(entity2))
-  })
-})

--- a/packages/miniplex-core/test/ids.test.ts
+++ b/packages/miniplex-core/test/ids.test.ts
@@ -1,0 +1,27 @@
+import { id, get } from "../src"
+
+describe("id", () => {
+  it("returns a numerical ID for the specified entity", () => {
+    const entity = {}
+    expect(id(entity)).toBe(0)
+  })
+
+  it("returns the same ID for the same entity", () => {
+    const entity = {}
+    expect(id(entity)).toBe(id(entity))
+  })
+
+  it("returns a different ID for different entities", () => {
+    const entity1 = {}
+    const entity2 = {}
+    expect(id(entity1)).not.toBe(id(entity2))
+  })
+})
+
+describe("get", () => {
+  it("returns the entity for the specified ID", () => {
+    const entity = {}
+    const entityId = id(entity)
+    expect(get(entityId)).toBe(entity)
+  })
+})


### PR DESCRIPTION
- Adds `get(id)`, the counterpart to `id(entity)`
- Extracts `id` tests into their own module
