### PR TITLE
Another quick rewrite :-)

### DIFF
--- a/.changeset/healthy-dragons-think.md
+++ b/.changeset/healthy-dragons-think.md
@@ -1,0 +1,25 @@
+---
+"@miniplex/core": patch
+---
+
+Aaaaah, another rewrite of the core library! `@miniplex/core` kept the same lightweight core, but the `World` is now much more aware of archetypes and what kind of entities they represent. This was done to allow for better introspection and to fix some remaining issues like [#204](https://github.com/hmans/miniplex/issues/204)].
+
+The `WithRequiredKeys` type has been renamed to `WithComponents`.
+
+`world.archetype()` now allows two forms:
+
+```ts
+world.archetype("position", "velocity")
+world.archetype({ all: ["position", "velocity"] })
+```
+
+The second form involves a query object that can also have `any` and `none` keys:
+
+```ts
+world.archetype({
+  all: ["position", "velocity"],
+  none: ["dead"]
+})
+```
+
+**Breaking Change:** `bucket.derive()` has been removed. It was cool and fun and cute, but also a little too generic to be useful. Similar to Miniplex 1.0, there is only the _world_ and a series of _archetypes_ now. (But both share the same lightweight `Bucket` base class that can also be used standalone.)

--- a/.changeset/quiet-bats-fetch.md
+++ b/.changeset/quiet-bats-fetch.md
@@ -1,0 +1,11 @@
+---
+"@miniplex/react": patch
+---
+
+`<Archetype>` has been changed to match the new query capabilities of the core library's `world.archetype` function. All of these are now valid:
+
+```tsx
+<Archetype query="position" />
+<Archetype query={["position", "velocity"]} />
+<Archetype query={{ all: ["position", "velocity"], none: ["dead"] }} />
+```

--- a/apps/demo/src/entities/Asteroids.tsx
+++ b/apps/demo/src/entities/Asteroids.tsx
@@ -1,5 +1,5 @@
 import { Composable, Modules } from "material-composer-r3f"
-import { WithRequiredKeys } from "miniplex"
+import { Archetype, WithRequiredComponents } from "miniplex"
 import { insideCircle, power } from "randomish"
 import { useLayoutEffect } from "react"
 import { $, Input, InstanceID, Lerp } from "shader-composer"
@@ -17,7 +17,7 @@ export const InstanceRNG =
     Random($`${offset} + float(${InstanceID}) * 1.1005`)
 
 export const Asteroids = () => {
-  const segmentedAsteroids = useSegmentedBucket(asteroids)
+  // const segmentedAsteroids = useSegmentedBucket(asteroids)
 
   console.log("Rerendering Asteroids component. You should only see this once.")
 
@@ -46,14 +46,16 @@ export const Asteroids = () => {
         />
       </Composable.MeshStandardMaterial>
 
-      {segmentedAsteroids.entities.map((segment, i) => (
+      {/* {segmentedAsteroids.entities.map((segment, i) => (
         <ECS.Bucket key={i} bucket={segment} as={RenderableEntity} />
-      ))}
+      ))} */}
+
+      <ECS.Bucket bucket={asteroids} as={RenderableEntity} />
     </InstancedParticles>
   )
 }
 
-export type Asteroid = WithRequiredKeys<
+export type Asteroid = WithRequiredComponents<
   Entity,
   | "isAsteroid"
   | "transform"
@@ -66,7 +68,7 @@ export type Asteroid = WithRequiredKeys<
 export const isAsteroid = (entity: Entity): entity is Asteroid =>
   "isAsteroid" in entity
 
-const asteroids = ECS.world.derive(isAsteroid)
+const asteroids = ECS.world.archetype("isAsteroid") as Archetype<Asteroid>
 
 const tmpVec3 = new Vector3()
 

--- a/apps/demo/src/entities/Asteroids.tsx
+++ b/apps/demo/src/entities/Asteroids.tsx
@@ -1,5 +1,5 @@
 import { Composable, Modules } from "material-composer-r3f"
-import { Archetype, WithRequiredComponents } from "miniplex"
+import { Archetype, WithComponents } from "miniplex"
 import { insideCircle, power } from "randomish"
 import { useLayoutEffect } from "react"
 import { $, Input, InstanceID, Lerp } from "shader-composer"
@@ -55,7 +55,7 @@ export const Asteroids = () => {
   )
 }
 
-export type Asteroid = WithRequiredComponents<
+export type Asteroid = WithComponents<
   Entity,
   | "isAsteroid"
   | "transform"
@@ -64,9 +64,6 @@ export type Asteroid = WithRequiredComponents<
   | "neighbors"
   | "render"
 >
-
-export const isAsteroid = (entity: Entity): entity is Asteroid =>
-  "isAsteroid" in entity
 
 const asteroids = ECS.world.archetype("isAsteroid") as Archetype<Asteroid>
 

--- a/apps/demo/src/entities/Asteroids.tsx
+++ b/apps/demo/src/entities/Asteroids.tsx
@@ -17,7 +17,7 @@ export const InstanceRNG =
     Random($`${offset} + float(${InstanceID}) * 1.1005`)
 
 export const Asteroids = () => {
-  // const segmentedAsteroids = useSegmentedBucket(asteroids)
+  const segmentedAsteroids = useSegmentedBucket(asteroids)
 
   console.log("Rerendering Asteroids component. You should only see this once.")
 
@@ -46,11 +46,11 @@ export const Asteroids = () => {
         />
       </Composable.MeshStandardMaterial>
 
-      {/* {segmentedAsteroids.entities.map((segment, i) => (
+      {segmentedAsteroids.entities.map((segment, i) => (
         <ECS.Bucket key={i} bucket={segment} as={RenderableEntity} />
-      ))} */}
+      ))}
 
-      <ECS.Bucket bucket={asteroids} as={RenderableEntity} />
+      {/* <ECS.Bucket bucket={asteroids} as={RenderableEntity} /> */}
     </InstancedParticles>
   )
 }

--- a/apps/demo/src/entities/Bullets.tsx
+++ b/apps/demo/src/entities/Bullets.tsx
@@ -12,7 +12,7 @@ export const Bullets = () => (
     <planeGeometry args={[0.15, 0.5]} />
     <meshStandardMaterial color={new Color("orange").multiplyScalar(5)} />
 
-    <ECS.Archetype components="isBullet" as={RenderableEntity} />
+    <ECS.Archetype query="isBullet" as={RenderableEntity} />
   </InstancedParticles>
 )
 

--- a/apps/demo/src/entities/RenderableEntity.tsx
+++ b/apps/demo/src/entities/RenderableEntity.tsx
@@ -1,8 +1,8 @@
-import { WithRequiredKeys } from "miniplex"
+import { WithComponents } from "miniplex"
 import { Entity } from "../state"
 
 export const RenderableEntity = ({
   entity
 }: {
-  entity: WithRequiredKeys<Entity, "render">
+  entity: WithComponents<Entity, "render">
 }) => <>{entity.render}</>

--- a/apps/demo/src/lib/SegmentedBucket.tsx
+++ b/apps/demo/src/lib/SegmentedBucket.tsx
@@ -1,7 +1,7 @@
 import { useConst } from "@hmans/use-const"
-import { Bucket } from "miniplex"
+import { Bucket, IEntity } from "miniplex"
 
-export class SegmentedBucket<E> extends Bucket<Bucket<E>> {
+export class SegmentedBucket<E extends IEntity> extends Bucket<Bucket<E>> {
   private entityToSegment = new Map<E, Bucket<E>>()
   private counter = 0
   private current = 0
@@ -43,7 +43,7 @@ export class SegmentedBucket<E> extends Bucket<Bucket<E>> {
   }
 }
 
-export const useSegmentedBucket = <E extends any>(
+export const useSegmentedBucket = <E extends IEntity>(
   source: Bucket<E>,
   size = 50
 ) => useConst(() => new SegmentedBucket(source, size))

--- a/apps/demo/src/lib/SegmentedBucket.tsx
+++ b/apps/demo/src/lib/SegmentedBucket.tsx
@@ -1,7 +1,7 @@
 import { useConst } from "@hmans/use-const"
-import { Bucket, IEntity } from "miniplex"
+import { Bucket } from "miniplex"
 
-export class SegmentedBucket<E extends IEntity> extends Bucket<Bucket<E>> {
+export class SegmentedBucket<E> extends Bucket<Bucket<E>> {
   private entityToSegment = new Map<E, Bucket<E>>()
   private counter = 0
   private current = 0
@@ -43,7 +43,7 @@ export class SegmentedBucket<E extends IEntity> extends Bucket<Bucket<E>> {
   }
 }
 
-export const useSegmentedBucket = <E extends IEntity>(
+export const useSegmentedBucket = <E extends any>(
   source: Bucket<E>,
   size = 50
 ) => useConst(() => new SegmentedBucket(source, size))

--- a/apps/demo/src/systems/physicsSystem.ts
+++ b/apps/demo/src/systems/physicsSystem.ts
@@ -1,9 +1,9 @@
 import { useFrame } from "@react-three/fiber"
-import { WithRequiredKeys } from "miniplex"
+import { WithComponents } from "miniplex"
 import { MathUtils, Vector3 } from "three"
 import { ECS, Entity } from "../state"
 
-type PhysicsEntity = WithRequiredKeys<Entity, "transform" | "physics">
+type PhysicsEntity = WithComponents<Entity, "transform" | "physics">
 
 const entities = ECS.world.archetype("transform", "physics")
 

--- a/apps/demo/src/systems/playerSystem.ts
+++ b/apps/demo/src/systems/playerSystem.ts
@@ -1,5 +1,5 @@
 import { useFrame } from "@react-three/fiber"
-import { WithRequiredKeys } from "miniplex"
+import { WithRequiredComponents } from "miniplex"
 import { Vector3 } from "three"
 import { spawnBullet } from "../entities/Bullets"
 import { ECS, Entity } from "../state"
@@ -9,10 +9,11 @@ const tmpVec3 = new Vector3()
 
 const isPlayer = (
   entity: Entity
-): entity is WithRequiredKeys<Entity, "transform" | "physics"> =>
+): entity is WithRequiredComponents<Entity, "transform" | "physics"> =>
   !!entity.isPlayer
 
-const players = ECS.world.derive(isPlayer)
+// const players = ECS.world.archetype(isPlayer)
+const players = ECS.world.archetype("isPlayer", "transform", "physics")
 
 let lastFireTime = 0
 

--- a/apps/demo/src/systems/playerSystem.ts
+++ b/apps/demo/src/systems/playerSystem.ts
@@ -1,5 +1,5 @@
 import { useFrame } from "@react-three/fiber"
-import { WithRequiredComponents } from "miniplex"
+import { Archetype, WithRequiredComponents } from "miniplex"
 import { Vector3 } from "three"
 import { spawnBullet } from "../entities/Bullets"
 import { ECS, Entity } from "../state"
@@ -7,13 +7,13 @@ import { useKeyboard } from "../util/useKeyboard"
 
 const tmpVec3 = new Vector3()
 
-const isPlayer = (
-  entity: Entity
-): entity is WithRequiredComponents<Entity, "transform" | "physics"> =>
-  !!entity.isPlayer
+type Player = WithRequiredComponents<
+  Entity,
+  "isPlayer" | "transform" | "physics"
+>
 
 // const players = ECS.world.archetype(isPlayer)
-const players = ECS.world.archetype("isPlayer", "transform", "physics")
+const players = ECS.world.archetype("isPlayer") as Archetype<Player>
 
 let lastFireTime = 0
 

--- a/apps/demo/src/systems/playerSystem.ts
+++ b/apps/demo/src/systems/playerSystem.ts
@@ -1,5 +1,5 @@
 import { useFrame } from "@react-three/fiber"
-import { Archetype, WithRequiredComponents } from "miniplex"
+import { Archetype, WithComponents } from "miniplex"
 import { Vector3 } from "three"
 import { spawnBullet } from "../entities/Bullets"
 import { ECS, Entity } from "../state"
@@ -7,10 +7,7 @@ import { useKeyboard } from "../util/useKeyboard"
 
 const tmpVec3 = new Vector3()
 
-type Player = WithRequiredComponents<
-  Entity,
-  "isPlayer" | "transform" | "physics"
->
+type Player = WithComponents<Entity, "isPlayer" | "transform" | "physics">
 
 // const players = ECS.world.archetype(isPlayer)
 const players = ECS.world.archetype("isPlayer") as Archetype<Player>

--- a/packages/miniplex-core/benchmark.ts
+++ b/packages/miniplex-core/benchmark.ts
@@ -1,4 +1,4 @@
-import { World } from "./src"
+import { With, World } from "./src"
 
 const entityCount = 1_000_000
 
@@ -166,7 +166,7 @@ profile("simulate", () => {
 
 profile("simulate (with archetypes)", () => {
   const world = new World<Entity>()
-  const withVelocity = world.archetype("velocity")
+  const withVelocity = world.archetype<With<Entity, "velocity">>("velocity")
 
   for (let i = 0; i < entityCount; i++)
     world.add({

--- a/packages/miniplex-core/benchmark.ts
+++ b/packages/miniplex-core/benchmark.ts
@@ -1,4 +1,4 @@
-import { With, World } from "./src"
+import { World } from "./src"
 
 const entityCount = 10_000
 

--- a/packages/miniplex-core/benchmark.ts
+++ b/packages/miniplex-core/benchmark.ts
@@ -166,7 +166,7 @@ profile("simulate", () => {
 
 profile("simulate (with archetypes)", () => {
   const world = new World<Entity>()
-  const withVelocity = world.archetype<With<Entity, "velocity">>("velocity")
+  const withVelocity = world.archetype("velocity")
 
   for (let i = 0; i < entityCount; i++)
     world.add({

--- a/packages/miniplex-core/benchmark.ts
+++ b/packages/miniplex-core/benchmark.ts
@@ -1,6 +1,6 @@
 import { World } from "./src"
 
-const entityCount = 10_000
+const entityCount = 1_000_000
 
 const profile = (name: string, setup: () => () => () => boolean) => {
   const test = setup()

--- a/packages/miniplex-core/benchmark.ts
+++ b/packages/miniplex-core/benchmark.ts
@@ -1,6 +1,6 @@
 import { With, World } from "./src"
 
-const entityCount = 1_000_000
+const entityCount = 10_000
 
 const profile = (name: string, setup: () => () => () => boolean) => {
   const test = setup()

--- a/packages/miniplex-core/src/Archetype.ts
+++ b/packages/miniplex-core/src/Archetype.ts
@@ -1,6 +1,11 @@
 import { Bucket } from "./Bucket"
 import { IEntity, Query } from "./types"
 
+/**
+ * A bucket type that stores entities belonging to a specific archetype.
+ * This archetype is expressed as a `Query` object, stored in the archetype's
+ * `query` property.
+ */
 export class Archetype<E extends IEntity> extends Bucket<E> {
   constructor(public query: Query<E>) {
     super()

--- a/packages/miniplex-core/src/Bucket.ts
+++ b/packages/miniplex-core/src/Bucket.ts
@@ -52,6 +52,12 @@ export class Bucket<E extends IEntity> {
     return entity
   }
 
+  clear() {
+    for (const entity of this) {
+      this.remove(entity)
+    }
+  }
+
   has(entity: E) {
     return this.entities.includes(entity)
   }

--- a/packages/miniplex-core/src/Bucket.ts
+++ b/packages/miniplex-core/src/Bucket.ts
@@ -1,11 +1,10 @@
-import { IEntity } from "./types"
 import { Event } from "@hmans/event"
 
-export type BucketOptions<E extends IEntity> = {
+export type BucketOptions<E> = {
   entities?: E[]
 }
 
-export class Bucket<E extends IEntity> {
+export class Bucket<E> {
   [Symbol.iterator]() {
     let index = this.entities.length
 

--- a/packages/miniplex-core/src/Bucket.ts
+++ b/packages/miniplex-core/src/Bucket.ts
@@ -61,7 +61,7 @@ export class Bucket<E> {
    * @returns The entity that was added.
    */
   add<D extends E>(entity: D): E & D {
-    if (!this.has(entity)) {
+    if (entity && !this.has(entity)) {
       this.entities.push(entity)
       this.entityPositions.set(entity, this.entities.length - 1)
       this.onEntityAdded.emit(entity)

--- a/packages/miniplex-core/src/Bucket.ts
+++ b/packages/miniplex-core/src/Bucket.ts
@@ -70,6 +70,12 @@ export class Bucket<E> {
     return entity
   }
 
+  /**
+   * Removes an entity from this bucket.
+   *
+   * @param entity The entity to remove from this bucket.
+   * @returns The entity.
+   */
   remove(entity: E) {
     const index = this.entityPositions.get(entity)
 

--- a/packages/miniplex-core/src/Bucket.ts
+++ b/packages/miniplex-core/src/Bucket.ts
@@ -61,7 +61,7 @@ export class Bucket<E> {
    * @returns The entity that was added.
    */
   add<D extends E>(entity: D): E & D {
-    if (entity && !this.has(entity)) {
+    if (entity !== undefined && !this.has(entity)) {
       this.entities.push(entity)
       this.entityPositions.set(entity, this.entities.length - 1)
       this.onEntityAdded.emit(entity)

--- a/packages/miniplex-core/src/Bucket.ts
+++ b/packages/miniplex-core/src/Bucket.ts
@@ -17,11 +17,25 @@ export class Bucket<E extends IEntity> {
     }
   }
 
+  /**
+   * All entities stored in this bucket.
+   */
   entities: E[]
 
+  /**
+   * A map of entities to their positions within the `entities` array.
+   * Used internally for performance optimizations.
+   */
   private entityPositions = new Map<E, number>()
 
+  /**
+   * An event that is emitted when an entity is added to this bucket.
+   */
   onEntityAdded = new Event<E>()
+
+  /**
+   * An event that is emitted when an entity is removed from this bucket.
+   */
   onEntityRemoved = new Event<E>()
 
   constructor({ entities = [] }: BucketOptions<E> = {}) {
@@ -33,10 +47,20 @@ export class Bucket<E extends IEntity> {
     }
   }
 
+  /**
+   * Returns the size of this bucket (equal to the number of entities stored
+   * within it.)
+   */
   get size() {
     return this.entities.length
   }
 
+  /**
+   * Adds an entity to this bucket.
+   *
+   * @param entity The entity to add to this bucket.
+   * @returns The entity that was added.
+   */
   add<D extends E>(entity: D): E & D {
     if (!this.has(entity)) {
       this.entities.push(entity)
@@ -77,6 +101,12 @@ export class Bucket<E extends IEntity> {
     this.entityPositions.clear()
   }
 
+  /**
+   * Returns `true` if the given entity is stored within this bucket.
+   *
+   * @param entity The entity to check for.
+   * @returns `true` if the given entity is stored within this bucket.
+   */
   has(entity: E) {
     return this.entityPositions.has(entity)
   }

--- a/packages/miniplex-core/src/Bucket.ts
+++ b/packages/miniplex-core/src/Bucket.ts
@@ -6,6 +6,17 @@ export type BucketOptions<E extends IEntity> = {
 }
 
 export class Bucket<E extends IEntity> {
+  [Symbol.iterator]() {
+    let index = this.entities.length
+
+    return {
+      next: () => {
+        const value = this.entities[--index]
+        return { value, done: index < 0 }
+      }
+    }
+  }
+
   entities: E[]
 
   onEntityAdded = new Event<E>()

--- a/packages/miniplex-core/src/Bucket.ts
+++ b/packages/miniplex-core/src/Bucket.ts
@@ -15,6 +15,10 @@ export class Bucket<E extends IEntity> {
     this.entities = opts.entities || []
   }
 
+  get size() {
+    return this.entities.length
+  }
+
   add(entity: E) {
     if (!this.has(entity)) {
       this.entities.push(entity)

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -60,6 +60,12 @@ export class World<E extends IEntity> extends Bucket<E> {
     delete entity[component]
   }
 
+  clear() {
+    for (const entity of this) {
+      this.remove(entity)
+    }
+  }
+
   archetype(first: keyof E, ...rest: (keyof E)[]): Archetype<E>
   archetype(query: Query<E>): Archetype<E>
   archetype(query: Query<E> | keyof E, ...rest: (keyof E)[]): Archetype<E> {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -63,13 +63,10 @@ export class World<E extends IEntity> extends Bucket<E> {
     entity[component] = value
 
     /* Re-check known archetypes */
-    for (const archetype of this.archetypes.values()) {
-      if (archetype.matchesEntity(entity)) {
-        archetype.add(entity)
-      } else {
-        archetype.remove(entity)
-      }
-    }
+    for (const archetype of this.archetypes.values())
+      archetype.matchesEntity(entity)
+        ? archetype.add(entity)
+        : archetype.remove(entity)
   }
 
   removeComponent<C extends keyof E>(entity: E, component: C) {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -60,7 +60,13 @@ export class World<E extends IEntity> extends Bucket<E> {
     delete entity[component]
   }
 
-  archetype(query: Query<E>): Archetype<E> {
+  archetype(first: keyof E, ...rest: (keyof E)[]): Archetype<E>
+  archetype(query: Query<E>): Archetype<E>
+  archetype(query: Query<E> | keyof E, ...rest: (keyof E)[]): Archetype<E> {
+    if (typeof query !== "object") {
+      return this.archetype({ all: [query, ...rest] })
+    }
+
     const normalizedQuery = normalizeQuery(query)
     const key = serializeQuery(normalizedQuery)
 

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -103,7 +103,11 @@ export class World<E extends IEntity> extends Bucket<E> {
     return this.query({ all: components })
   }
 
-  query<D extends E>(query: Query<E>): Archetype<D> {
+  query<D extends WithRequiredComponents<E, C>, C extends keyof E>(query: {
+    all?: C[]
+    any?: (keyof E)[]
+    none?: (keyof E)[]
+  }): Archetype<D> {
     const normalizedQuery = normalizeQuery(query)
     const key = serializeQuery(normalizedQuery)
 

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -9,7 +9,7 @@ export type WorldOptions<E extends IEntity> = {
 
 export class World<E extends IEntity> extends Bucket<E> {
   /* Archetypes */
-  private archetypes = new Map<string, Archetype<E>>()
+  private archetypes = new Map<string, Archetype<any>>()
 
   /* Entity IDs */
   private nextID = 0
@@ -125,6 +125,6 @@ export class World<E extends IEntity> extends Bucket<E> {
     }
 
     /* We're done, return the archetype */
-    return this.archetypes.get(key)! as unknown as Archetype<D>
+    return this.archetypes.get(key)! as Archetype<D>
   }
 }

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -60,9 +60,12 @@ export class World<E extends IEntity> extends Bucket<E> {
     delete entity[component]
   }
 
-  archetype(first: keyof E, ...rest: (keyof E)[]): Archetype<E>
-  archetype(query: Query<E>): Archetype<E>
-  archetype(query: Query<E> | keyof E, ...rest: (keyof E)[]): Archetype<E> {
+  archetype<D extends E = E>(first: keyof E, ...rest: (keyof E)[]): Archetype<D>
+  archetype<D extends E = E>(query: Query<E>): Archetype<D>
+  archetype<D extends E = E>(
+    query: Query<E> | keyof E,
+    ...rest: (keyof E)[]
+  ): Archetype<D> {
     if (typeof query !== "object") {
       return this.archetype({ all: [query, ...rest] })
     }
@@ -71,7 +74,7 @@ export class World<E extends IEntity> extends Bucket<E> {
     const key = serializeQuery(normalizedQuery)
 
     if (this.archetypes.has(key)) {
-      return this.archetypes.get(key)!
+      return this.archetypes.get(key)! as unknown as Archetype<D>
     }
 
     /* Create archetype and remember it for later */
@@ -86,6 +89,6 @@ export class World<E extends IEntity> extends Bucket<E> {
     }
 
     /* We're done, return the archetype */
-    return archetype
+    return archetype as unknown as Archetype<D>
   }
 }

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -108,13 +108,7 @@ export class World<E extends IEntity> extends Bucket<E> {
   }): Archetype<D>
 
   archetype<D extends WithRequiredComponents<E, C>, C extends keyof E>(
-    query:
-      | {
-          all?: C[]
-          any?: (keyof E)[]
-          none?: (keyof E)[]
-        }
-      | C,
+    query: Query<E, C> | C,
     ...extra: C[]
   ): Archetype<D> {
     if (typeof query !== "object") {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -30,6 +30,8 @@ export class World<E extends IEntity> extends Bucket<E> {
   }
 
   remove(entity: E) {
+    if (!this.has(entity)) return entity
+
     /* Remove entity from all archetypes */
     for (const archetype of this.archetypes.values()) {
       archetype.remove(entity)
@@ -44,7 +46,9 @@ export class World<E extends IEntity> extends Bucket<E> {
   }
 
   id(entity: E) {
-    if (!this.entityToID.has(entity) && this.has(entity)) {
+    if (!this.has(entity)) return
+
+    if (!this.entityToID.has(entity)) {
       const id = this.nextID++
       this.entityToID.set(entity, id)
       this.idToEntity.set(id, entity)

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -97,20 +97,13 @@ export class World<E extends IEntity> extends Bucket<E> {
     delete entity[component]
   }
 
-  archetype<D extends E, C extends keyof E>(
+  archetype<D extends WithRequiredComponents<E, C>, C extends keyof E>(
     ...components: C[]
-  ): Archetype<WithRequiredComponents<E, C>>
-
-  archetype<D extends E>(query: Query<E>): Archetype<D>
-
-  archetype<D extends E, C extends keyof E>(
-    query: Query<E> | C,
-    ...rest: C[]
   ): Archetype<D> {
-    if (typeof query !== "object") {
-      return this.archetype({ all: [query, ...rest] })
-    }
+    return this.query({ all: components })
+  }
 
+  query<D extends E>(query: Query<E>): Archetype<D> {
     const normalizedQuery = normalizeQuery(query)
     const key = serializeQuery(normalizedQuery)
 

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -91,11 +91,11 @@ export class World<E extends IEntity> extends Bucket<E> {
     ...components: C[]
   ): Archetype<WithRequiredComponents<E, C>>
 
-  archetype<D extends E = E>(query: Query<E>): Archetype<D>
+  archetype<D extends E>(query: Query<E>): Archetype<D>
 
-  archetype<D extends E = E>(
-    query: Query<E> | keyof E,
-    ...rest: (keyof E)[]
+  archetype<D extends E, C extends keyof E>(
+    query: Query<E> | C,
+    ...rest: C[]
   ): Archetype<D> {
     if (typeof query !== "object") {
       return this.archetype({ all: [query, ...rest] })

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -1,6 +1,6 @@
 import { Archetype } from "./Archetype"
 import { Bucket } from "./Bucket"
-import { serializeQuery } from "./queries"
+import { normalizeQuery, serializeQuery } from "./queries"
 import { IEntity, Query } from "./types"
 
 export type WorldOptions<E extends IEntity> = {
@@ -61,11 +61,16 @@ export class World<E extends IEntity> extends Bucket<E> {
   }
 
   archetype(query: Query<E>): Archetype<E> {
-    // TODO: normalize query
+    const normalizedQuery = normalizeQuery(query)
+    const key = serializeQuery(normalizedQuery)
+
+    if (this.archetypes.has(key)) {
+      return this.archetypes.get(key)!
+    }
 
     /* Create archetype and remember it for later */
-    const archetype = new Archetype(query)
-    this.archetypes.set(serializeQuery(query), archetype)
+    const archetype = new Archetype(normalizedQuery)
+    this.archetypes.set(key, archetype)
 
     /* Check existing entities for matches */
     for (const entity of this.entities) {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -97,20 +97,20 @@ export class World<E extends IEntity> extends Bucket<E> {
     delete entity[component]
   }
 
-  archetype<D extends WithComponents<E, C>, C extends keyof E>(
+  archetype<C extends keyof E>(
     ...components: C[]
-  ): Archetype<D>
+  ): Archetype<WithComponents<E, C>>
 
-  archetype<D extends WithComponents<E, C>, C extends keyof E>(query: {
+  archetype<C extends keyof E>(query: {
     all?: C[]
     any?: (keyof E)[]
     none?: (keyof E)[]
-  }): Archetype<D>
+  }): Archetype<WithComponents<E, C>>
 
-  archetype<D extends WithComponents<E, C>, C extends keyof E>(
+  archetype<C extends keyof E>(
     query: Query<E, C> | C,
     ...extra: C[]
-  ): Archetype<D> {
+  ): Archetype<WithComponents<E, C>> {
     if (typeof query !== "object") {
       return this.archetype({ all: [query, ...extra] })
     }
@@ -132,6 +132,6 @@ export class World<E extends IEntity> extends Bucket<E> {
     }
 
     /* We're done, return the archetype */
-    return this.archetypes.get(key)! as Archetype<D>
+    return this.archetypes.get(key)! as Archetype<WithComponents<E, C>>
   }
 }

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -97,10 +97,27 @@ export class World<E extends IEntity> extends Bucket<E> {
     delete entity[component]
   }
 
+  /**
+   * Returns an archetype bucket holding all entities that have all of the specified
+   * components.
+   *
+   * @param components One or multiple components to query for
+   */
   archetype<C extends keyof E>(
     ...components: C[]
   ): Archetype<WithComponents<E, C>>
 
+  /**
+   * Returns an archetype bucket holding all entities that match the specified
+   * query. The query is a simple object with optional `all`, `any` and `none`
+   * keys. Each key should be an array of component names.
+   *
+   * The `all` key specifies that all of the components in the array must be present.
+   * The `any` key specifies that at least one of the components in the array must be present.
+   * The `none` key specifies that none of the components in the array must be present.
+   *
+   * @param query
+   */
   archetype<C extends keyof E>(query: {
     all?: C[]
     any?: (keyof E)[]

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -83,10 +83,11 @@ export class World<E extends IEntity> extends Bucket<E> {
 
     /* Re-check known archetypes */
     if (this.has(entity)) {
-      const components = Object.keys(entity).filter((c) => c !== component)
+      const copy = { ...entity }
+      delete copy[component]
 
       for (const archetype of this.archetypes.values())
-        archetype.matchesComponents(components)
+        archetype.matchesEntity(copy)
           ? archetype.add(entity)
           : archetype.remove(entity)
     }

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -99,15 +99,28 @@ export class World<E extends IEntity> extends Bucket<E> {
 
   archetype<D extends WithRequiredComponents<E, C>, C extends keyof E>(
     ...components: C[]
-  ): Archetype<D> {
-    return this.query({ all: components })
-  }
+  ): Archetype<D>
 
-  query<D extends WithRequiredComponents<E, C>, C extends keyof E>(query: {
+  archetype<D extends WithRequiredComponents<E, C>, C extends keyof E>(query: {
     all?: C[]
     any?: (keyof E)[]
     none?: (keyof E)[]
-  }): Archetype<D> {
+  }): Archetype<D>
+
+  archetype<D extends WithRequiredComponents<E, C>, C extends keyof E>(
+    query:
+      | {
+          all?: C[]
+          any?: (keyof E)[]
+          none?: (keyof E)[]
+        }
+      | C,
+    ...extra: C[]
+  ): Archetype<D> {
+    if (typeof query !== "object") {
+      return this.archetype({ all: [query, ...extra] })
+    }
+
     const normalizedQuery = normalizeQuery(query)
     const key = serializeQuery(normalizedQuery)
 

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -1,5 +1,6 @@
 import { Archetype } from "./Archetype"
 import { Bucket } from "./Bucket"
+import { serializeQuery } from "./queries"
 import { IEntity, Query } from "./types"
 
 export type WorldOptions<E extends IEntity> = {
@@ -7,13 +8,13 @@ export type WorldOptions<E extends IEntity> = {
 }
 
 export class World<E extends IEntity> extends Bucket<E> {
-  private archetypes = new Map<Query<E>, Archetype<E>>()
+  private archetypes = new Map<string, Archetype<E>>()
 
   add(entity: E) {
     super.add(entity)
 
     /* Add entity to matching archetypes */
-    for (const [query, archetype] of this.archetypes) {
+    for (const archetype of this.archetypes.values()) {
       if (archetype.matchesEntity(entity)) {
         archetype.add(entity)
       }
@@ -35,7 +36,7 @@ export class World<E extends IEntity> extends Bucket<E> {
     entity[component] = value
 
     /* Re-check known archetypes */
-    for (const [query, archetype] of this.archetypes) {
+    for (const archetype of this.archetypes.values()) {
       if (archetype.matchesEntity(entity)) {
         archetype.add(entity)
       } else {
@@ -48,7 +49,7 @@ export class World<E extends IEntity> extends Bucket<E> {
     const components = Object.keys(entity).filter((c) => c !== component)
 
     /* Re-check known archetypes */
-    for (const [query, archetype] of this.archetypes)
+    for (const archetype of this.archetypes.values())
       archetype.matchesComponents(components)
         ? archetype.add(entity)
         : archetype.remove(entity)
@@ -63,8 +64,8 @@ export class World<E extends IEntity> extends Bucket<E> {
     // TODO: normalize query
 
     /* Create archetype and remember it for later */
-    const archetype = new Archetype<E>(query)
-    this.archetypes.set(query, archetype)
+    const archetype = new Archetype(query)
+    this.archetypes.set(serializeQuery(query), archetype)
 
     /* Check existing entities for matches */
     for (const entity of this.entities) {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -63,20 +63,23 @@ export class World<E extends IEntity> extends Bucket<E> {
     entity[component] = value
 
     /* Re-check known archetypes */
-    for (const archetype of this.archetypes.values())
-      archetype.matchesEntity(entity)
-        ? archetype.add(entity)
-        : archetype.remove(entity)
+    if (this.has(entity))
+      for (const archetype of this.archetypes.values())
+        archetype.matchesEntity(entity)
+          ? archetype.add(entity)
+          : archetype.remove(entity)
   }
 
   removeComponent<C extends keyof E>(entity: E, component: C) {
-    const components = Object.keys(entity).filter((c) => c !== component)
-
     /* Re-check known archetypes */
-    for (const archetype of this.archetypes.values())
-      archetype.matchesComponents(components)
-        ? archetype.add(entity)
-        : archetype.remove(entity)
+    if (this.has(entity)) {
+      const components = Object.keys(entity).filter((c) => c !== component)
+
+      for (const archetype of this.archetypes.values())
+        archetype.matchesComponents(components)
+          ? archetype.add(entity)
+          : archetype.remove(entity)
+    }
 
     /* At this point, all relevant callbacks will have executed. Now it's
     safe to remove the component. */

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -1,7 +1,7 @@
 import { Archetype } from "./Archetype"
 import { Bucket } from "./Bucket"
 import { normalizeQuery, serializeQuery } from "./queries"
-import { IEntity, Query, WithRequiredComponents } from "./types"
+import { IEntity, Query, WithComponents } from "./types"
 
 export type WorldOptions<E extends IEntity> = {
   entities?: E[]
@@ -97,17 +97,17 @@ export class World<E extends IEntity> extends Bucket<E> {
     delete entity[component]
   }
 
-  archetype<D extends WithRequiredComponents<E, C>, C extends keyof E>(
+  archetype<D extends WithComponents<E, C>, C extends keyof E>(
     ...components: C[]
   ): Archetype<D>
 
-  archetype<D extends WithRequiredComponents<E, C>, C extends keyof E>(query: {
+  archetype<D extends WithComponents<E, C>, C extends keyof E>(query: {
     all?: C[]
     any?: (keyof E)[]
     none?: (keyof E)[]
   }): Archetype<D>
 
-  archetype<D extends WithRequiredComponents<E, C>, C extends keyof E>(
+  archetype<D extends WithComponents<E, C>, C extends keyof E>(
     query: Query<E, C> | C,
     ...extra: C[]
   ): Archetype<D> {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -60,12 +60,6 @@ export class World<E extends IEntity> extends Bucket<E> {
     delete entity[component]
   }
 
-  clear() {
-    for (const entity of this) {
-      this.remove(entity)
-    }
-  }
-
   archetype(first: keyof E, ...rest: (keyof E)[]): Archetype<E>
   archetype(query: Query<E>): Archetype<E>
   archetype(query: Query<E> | keyof E, ...rest: (keyof E)[]): Archetype<E> {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -60,6 +60,9 @@ export class World<E extends IEntity> extends Bucket<E> {
   }
 
   addComponent<C extends keyof E>(entity: E, component: C, value: E[C]) {
+    /* Don't overwrite existing components */
+    if (entity[component] !== undefined) return
+
     entity[component] = value
 
     /* Re-check known archetypes */
@@ -71,6 +74,9 @@ export class World<E extends IEntity> extends Bucket<E> {
   }
 
   removeComponent<C extends keyof E>(entity: E, component: C) {
+    /* Return early if component doesn't exist on entity */
+    if (entity[component] === undefined) return
+
     /* Re-check known archetypes */
     if (this.has(entity)) {
       const components = Object.keys(entity).filter((c) => c !== component)

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -111,15 +111,18 @@ export class World<E extends IEntity> extends Bucket<E> {
     query: Query<E, C> | C,
     ...extra: C[]
   ): Archetype<WithComponents<E, C>> {
+    /* If the query is not a query object, turn it into one and call
+    ourselves. Yay overloading in TypeScript! */
     if (typeof query !== "object") {
       return this.archetype({ all: [query, ...extra] })
     }
 
+    /* Build a normalized query object and key */
     const normalizedQuery = normalizeQuery(query)
     const key = serializeQuery(normalizedQuery)
 
+    /* If we haven't seen this query before, create a new archetype */
     if (!this.archetypes.has(key)) {
-      /* Create archetype and remember it for later */
       const archetype = new Archetype(normalizedQuery)
       this.archetypes.set(key, archetype)
 
@@ -131,7 +134,7 @@ export class World<E extends IEntity> extends Bucket<E> {
       }
     }
 
-    /* We're done, return the archetype */
+    /* We're done, return the archetype! */
     return this.archetypes.get(key)! as Archetype<WithComponents<E, C>>
   }
 }

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -114,22 +114,20 @@ export class World<E extends IEntity> extends Bucket<E> {
     const normalizedQuery = normalizeQuery(query)
     const key = serializeQuery(normalizedQuery)
 
-    if (this.archetypes.has(key)) {
-      return this.archetypes.get(key)! as unknown as Archetype<D>
-    }
+    if (!this.archetypes.has(key)) {
+      /* Create archetype and remember it for later */
+      const archetype = new Archetype(normalizedQuery)
+      this.archetypes.set(key, archetype)
 
-    /* Create archetype and remember it for later */
-    const archetype = new Archetype(normalizedQuery)
-    this.archetypes.set(key, archetype)
-
-    /* Check existing entities for matches */
-    for (const entity of this.entities) {
-      if (archetype.matchesEntity(entity)) {
-        archetype.add(entity)
+      /* Check existing entities for matches */
+      for (const entity of this.entities) {
+        if (archetype.matchesEntity(entity)) {
+          archetype.add(entity)
+        }
       }
     }
 
     /* We're done, return the archetype */
-    return archetype as unknown as Archetype<D>
+    return this.archetypes.get(key)! as unknown as Archetype<D>
   }
 }

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -1,7 +1,7 @@
 import { Archetype } from "./Archetype"
 import { Bucket } from "./Bucket"
 import { normalizeQuery, serializeQuery } from "./queries"
-import { IEntity, Query } from "./types"
+import { IEntity, Query, With } from "./types"
 
 export type WorldOptions<E extends IEntity> = {
   entities?: E[]
@@ -60,8 +60,12 @@ export class World<E extends IEntity> extends Bucket<E> {
     delete entity[component]
   }
 
-  archetype<D extends E = E>(first: keyof E, ...rest: (keyof E)[]): Archetype<D>
+  archetype<D extends E, C extends keyof E>(
+    ...components: C[]
+  ): Archetype<With<E, C>>
+
   archetype<D extends E = E>(query: Query<E>): Archetype<D>
+
   archetype<D extends E = E>(
     query: Query<E> | keyof E,
     ...rest: (keyof E)[]

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -19,11 +19,6 @@ export class World<E extends IEntity> extends Bucket<E> {
   add<D extends E>(entity: D): E & D {
     super.add(entity)
 
-    /* Generate an ID */
-    const id = this.nextID++
-    this.entityToID.set(entity, id)
-    this.idToEntity.set(id, entity)
-
     /* Add entity to matching archetypes */
     for (const archetype of this.archetypes.values()) {
       if (archetype.matchesEntity(entity)) {
@@ -49,6 +44,14 @@ export class World<E extends IEntity> extends Bucket<E> {
   }
 
   id(entity: E) {
+    if (!this.entityToID.has(entity) && this.has(entity)) {
+      const id = this.nextID++
+      this.entityToID.set(entity, id)
+      this.idToEntity.set(id, entity)
+
+      return id
+    }
+
     return this.entityToID.get(entity)
   }
 

--- a/packages/miniplex-core/src/index.ts
+++ b/packages/miniplex-core/src/index.ts
@@ -1,2 +1,4 @@
+export * from "./Archetype"
+export * from "./Bucket"
 export * from "./types"
 export * from "./World"

--- a/packages/miniplex-core/src/index.ts
+++ b/packages/miniplex-core/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./Archetype"
 export * from "./Bucket"
-export * from "./queries"
 export * from "./types"
 export * from "./World"

--- a/packages/miniplex-core/src/index.ts
+++ b/packages/miniplex-core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./Archetype"
 export * from "./Bucket"
+export * from "./queries"
 export * from "./types"
 export * from "./World"

--- a/packages/miniplex-core/src/queries.ts
+++ b/packages/miniplex-core/src/queries.ts
@@ -12,3 +12,7 @@ export const normalizeQuery = <E extends IEntity>(query: Query<E>) => ({
 
 export const serializeQuery = <E extends IEntity>(query: Query<E>) =>
   JSON.stringify(query)
+
+export const all = <E>(...components: (keyof E)[]) => ({
+  all: components
+})

--- a/packages/miniplex-core/src/queries.ts
+++ b/packages/miniplex-core/src/queries.ts
@@ -12,31 +12,3 @@ export const normalizeQuery = <E extends IEntity>(query: Query<E>) => ({
 
 export const serializeQuery = <E extends IEntity>(query: Query<E>) =>
   JSON.stringify(query)
-
-class QueryBuilder<E extends IEntity> {
-  query: Query<E> = {}
-
-  all(...components: (keyof E)[]) {
-    this.query.all = components
-    return this
-  }
-
-  any(...components: (keyof E)[]) {
-    this.query.any = components
-    return this
-  }
-
-  none(...components: (keyof E)[]) {
-    this.query.none = components
-    return this
-  }
-}
-
-export const all = <E extends IEntity>(...components: (keyof E)[]) =>
-  new QueryBuilder<E>().all(...components)
-
-export const any = <E extends IEntity>(...components: (keyof E)[]) =>
-  new QueryBuilder<E>().any(...components)
-
-export const none = <E extends IEntity>(...components: (keyof E)[]) =>
-  new QueryBuilder<E>().none(...components)

--- a/packages/miniplex-core/src/queries.ts
+++ b/packages/miniplex-core/src/queries.ts
@@ -13,6 +13,30 @@ export const normalizeQuery = <E extends IEntity>(query: Query<E>) => ({
 export const serializeQuery = <E extends IEntity>(query: Query<E>) =>
   JSON.stringify(query)
 
-export const all = <E>(...components: (keyof E)[]) => ({
-  all: components
-})
+class QueryBuilder<E extends IEntity> {
+  query: Query<E> = {}
+
+  all(...components: (keyof E)[]) {
+    this.query.all = components
+    return this
+  }
+
+  any(...components: (keyof E)[]) {
+    this.query.any = components
+    return this
+  }
+
+  none(...components: (keyof E)[]) {
+    this.query.none = components
+    return this
+  }
+}
+
+export const all = <E extends IEntity>(...components: (keyof E)[]) =>
+  new QueryBuilder<E>().all(...components)
+
+export const any = <E extends IEntity>(...components: (keyof E)[]) =>
+  new QueryBuilder<E>().any(...components)
+
+export const none = <E extends IEntity>(...components: (keyof E)[]) =>
+  new QueryBuilder<E>().none(...components)

--- a/packages/miniplex-core/src/queries.ts
+++ b/packages/miniplex-core/src/queries.ts
@@ -9,3 +9,6 @@ export const normalizeQuery = <E extends IEntity>(query: Query<E>) => ({
   any: query.any && normalizeComponents(query.any),
   none: query.none && normalizeComponents(query.none)
 })
+
+export const serializeQuery = <E extends IEntity>(query: Query<E>) =>
+  JSON.stringify(query)

--- a/packages/miniplex-core/src/types.ts
+++ b/packages/miniplex-core/src/types.ts
@@ -2,7 +2,9 @@ export interface IEntity {
   [key: string]: any
 }
 
-export type With<E, P extends keyof E> = E & { [K in P]-?: E[K] }
+export type WithRequiredComponents<E, P extends keyof E> = E & {
+  [K in P]-?: E[K]
+}
 
 export type Query<E extends IEntity> = {
   all?: (keyof E)[]

--- a/packages/miniplex-core/src/types.ts
+++ b/packages/miniplex-core/src/types.ts
@@ -6,8 +6,8 @@ export type WithRequiredComponents<E, P extends keyof E> = E & {
   [K in P]-?: E[K]
 }
 
-export interface Query<E extends IEntity> {
-  all?: (keyof E)[]
+export interface Query<E extends IEntity, All extends keyof E = keyof E> {
+  all?: All[]
   any?: (keyof E)[]
   none?: (keyof E)[]
 }

--- a/packages/miniplex-core/src/types.ts
+++ b/packages/miniplex-core/src/types.ts
@@ -2,7 +2,7 @@ export interface IEntity {
   [key: string]: any
 }
 
-export type WithRequiredComponents<E, P extends keyof E> = E & {
+export type WithComponents<E, P extends keyof E> = E & {
   [K in P]-?: E[K]
 }
 

--- a/packages/miniplex-core/src/types.ts
+++ b/packages/miniplex-core/src/types.ts
@@ -6,7 +6,7 @@ export type WithRequiredComponents<E, P extends keyof E> = E & {
   [K in P]-?: E[K]
 }
 
-export type Query<E extends IEntity> = {
+export interface Query<E extends IEntity> {
   all?: (keyof E)[]
   any?: (keyof E)[]
   none?: (keyof E)[]

--- a/packages/miniplex-core/test/Archetype.test.ts
+++ b/packages/miniplex-core/test/Archetype.test.ts
@@ -1,3 +1,4 @@
+import { World } from "../src"
 import { Archetype } from "../src/Archetype"
 
 describe("Archetype", () => {
@@ -43,6 +44,43 @@ describe("Archetype", () => {
       const archetype = new Archetype<Entity>({ none: ["age"] })
       const entity = { name: "John", age: 42 }
       expect(archetype.matchesEntity(entity)).toBe(false)
+    })
+  })
+
+  describe("onEntityRemoved", () => {
+    it("is invoked when an entity leaves the archetype", () => {
+      const world = new World<Entity>()
+
+      const archetype = world.archetype({ all: ["age"] })
+      const callback = jest.fn()
+      archetype.onEntityRemoved.add(callback)
+
+      const entity = world.add({ name: "John", age: 42 })
+      expect(callback).not.toHaveBeenCalled()
+
+      world.removeComponent(entity, "age")
+
+      expect(callback).toHaveBeenCalledWith(entity)
+    })
+
+    it("is invoked before the component is actually removed from the entity", () => {
+      const world = new World<Entity>()
+
+      let age: number | undefined
+
+      const archetype = world.archetype({ all: ["age"] })
+
+      const callback = jest.fn((entity: Entity) => {
+        age = entity.age
+      })
+
+      archetype.onEntityRemoved.add(callback)
+
+      const entity = world.add({ name: "John", age: 42 })
+      world.removeComponent(entity, "age")
+
+      expect(callback).toHaveBeenCalledWith(entity)
+      expect(age).toBe(42)
     })
   })
 })

--- a/packages/miniplex-core/test/Archetype.test.ts
+++ b/packages/miniplex-core/test/Archetype.test.ts
@@ -65,20 +65,22 @@ describe("Archetype", () => {
 
     it("is invoked before the component is actually removed from the entity", () => {
       const world = new World<Entity>()
-
-      let age: number | undefined
-
       const archetype = world.archetype({ all: ["age"] })
 
+      /* Set up a callback */
+      let age: number | undefined
       const callback = jest.fn((entity: Entity) => {
         age = entity.age
       })
-
       archetype.onEntityRemoved.add(callback)
 
+      /* Add an entity */
       const entity = world.add({ name: "John", age: 42 })
+
+      /* Remove the 'age' component */
       world.removeComponent(entity, "age")
 
+      /* Verify that the callback was invoked before the component was removed */
       expect(callback).toHaveBeenCalledWith(entity)
       expect(age).toBe(42)
     })

--- a/packages/miniplex-core/test/Bucket.test.ts
+++ b/packages/miniplex-core/test/Bucket.test.ts
@@ -38,12 +38,12 @@ describe("Bucket", () => {
 
   describe("remove", () => {
     it("removes an entity from the world", () => {
-      const entity = { id: 0 }
-      const world = new Bucket({ entities: [entity] })
-      expect(world.entities).toEqual([entity])
+      const entity = { name: "John" }
+      const bucket = new Bucket({ entities: [entity] })
+      expect(bucket.entities).toEqual([entity])
 
-      world.remove(entity)
-      expect(world.entities).toEqual([])
+      bucket.remove(entity)
+      expect(bucket.entities).toEqual([])
     })
 
     it("no-ops if it doesn't have the entity", () => {

--- a/packages/miniplex-core/test/Bucket.test.ts
+++ b/packages/miniplex-core/test/Bucket.test.ts
@@ -54,4 +54,11 @@ describe("Bucket", () => {
       expect(world.entities).toEqual([])
     })
   })
+
+  describe("size", () => {
+    it("returns the number of entities in the bucket", () => {
+      const bucket = new Bucket({ entities: [{ id: 0 }, { id: 1 }] })
+      expect(bucket.size).toBe(2)
+    })
+  })
 })

--- a/packages/miniplex-core/test/Bucket.test.ts
+++ b/packages/miniplex-core/test/Bucket.test.ts
@@ -61,4 +61,11 @@ describe("Bucket", () => {
       expect(bucket.size).toBe(2)
     })
   })
+
+  describe("Symbol.iterator", () => {
+    it("iterates over entities in a reversed order", () => {
+      const bucket = new Bucket({ entities: [{ id: 0 }, { id: 1 }] })
+      expect([...bucket]).toEqual([{ id: 1 }, { id: 0 }])
+    })
+  })
 })

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -72,6 +72,13 @@ describe("World", () => {
       expect(entity).toEqual({ name: "John", age: 42 })
     })
 
+    it("it doesn't overwrite the component if it already exists", () => {
+      const world = new World<{ name: string; age?: number }>()
+      const entity = world.add({ name: "John", age: 42 })
+      world.addComponent(entity, "age", 43)
+      expect(entity).toEqual({ name: "John", age: 42 })
+    })
+
     it("adds the entity to matching archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
       const archetype = world.archetype({ all: ["age"] })

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -5,7 +5,7 @@ describe("World", () => {
   describe("archetype", () => {
     it("creates an archetype for the given query", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.archetype({ all: ["name"] })
+      const archetype = world.archetype("name")
       expect(archetype).toBeDefined()
       expect(archetype).toBeInstanceOf(Archetype)
     })
@@ -13,21 +13,21 @@ describe("World", () => {
     it("supports a list of components as a shortcut", () => {
       const world = new World<{ name: string; age?: number }>()
       const archetype1 = world.archetype("name")
-      const archetype2 = world.archetype({ all: ["name"] })
+      const archetype2 = world.query({ all: ["name"] })
       expect(archetype1).toBe(archetype2)
     })
 
     it("returns the same archetype if it already exists", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype1 = world.archetype({ all: ["name"] })
-      const archetype2 = world.archetype({ all: ["name"] })
+      const archetype1 = world.query({ all: ["name"] })
+      const archetype2 = world.query({ all: ["name"] })
       expect(archetype1).toBe(archetype2)
     })
 
     it("properly normalizes queries before matching against existing archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype1 = world.archetype({ all: ["age", "name"] })
-      const archetype2 = world.archetype({ all: ["name", "age"] })
+      const archetype1 = world.query({ all: ["age", "name"] })
+      const archetype2 = world.query({ all: ["name", "age"] })
       expect(archetype1).toBe(archetype2)
     })
 
@@ -36,7 +36,7 @@ describe("World", () => {
       const entity = world.add({ name: "John", age: 42 })
       world.add({ name: "Alice" })
 
-      const archetype = world.archetype({ all: ["age"] })
+      const archetype = world.query({ all: ["age"] })
       expect(archetype.entities).toEqual([entity])
     })
   })
@@ -44,7 +44,7 @@ describe("World", () => {
   describe("add", () => {
     it("adds the entity to matching archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.archetype({ all: ["age"] })
+      const archetype = world.query({ all: ["age"] })
 
       const entity = world.add({ name: "John", age: 42 })
       expect(archetype.entities).toEqual([entity])
@@ -54,7 +54,7 @@ describe("World", () => {
   describe("remove", () => {
     it("removes the entity from all archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.archetype({ all: ["age"] })
+      const archetype = world.query({ all: ["age"] })
 
       const entity = world.add({ name: "John", age: 42 })
       expect(archetype.entities).toEqual([entity])
@@ -81,7 +81,7 @@ describe("World", () => {
 
     it("adds the entity to matching archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.archetype({ all: ["age"] })
+      const archetype = world.query({ all: ["age"] })
       const entity = world.add({ name: "John" })
 
       expect(archetype.entities).toEqual([])
@@ -101,7 +101,7 @@ describe("World", () => {
 
     it("removes the entity from archetype it no longer matches with", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.archetype({ all: ["age"] })
+      const archetype = world.query({ all: ["age"] })
       const entity = world.add({ name: "John", age: 42 })
 
       expect(archetype.entities).toEqual([entity])
@@ -148,7 +148,7 @@ describe("World", () => {
 
     it("also removes all entities from known archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.archetype({ all: ["age"] })
+      const archetype = world.query({ all: ["age"] })
       const john = world.add({ name: "John", age: 42 })
       world.add({ name: "Alice" })
       expect(archetype.entities).toEqual([john])

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -104,6 +104,32 @@ describe("World", () => {
     })
   })
 
+  describe("id", () => {
+    it("returns a unique ID for the given entity", () => {
+      const world = new World<{ name: string; age?: number }>()
+      const entity = world.add({ name: "John" })
+      expect(world.id(entity)).toEqual(0)
+
+      const entity2 = world.add({ name: "Alice" })
+      expect(world.id(entity2)).toEqual(1)
+    })
+
+    it("returns undefined if the entity is not part of the world", () => {
+      const world = new World<{ name: string; age?: number }>()
+      const entity = { name: "John" }
+      expect(world.id(entity)).toBeUndefined()
+    })
+  })
+
+  describe("entity", () => {
+    it("returns the entity matching the given ID", () => {
+      const world = new World<{ name: string; age?: number }>()
+      const entity = world.add({ name: "John" })
+      const id = world.id(entity)!
+      expect(world.entity(id)).toEqual(entity)
+    })
+  })
+
   describe("clear", () => {
     it("removes all known entities from the world", () => {
       const world = new World<{ name: string; age?: number }>()

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -103,4 +103,24 @@ describe("World", () => {
       expect(archetype.entities).toEqual([])
     })
   })
+
+  describe("clear", () => {
+    it("removes all known entities from the world", () => {
+      const world = new World<{ name: string; age?: number }>()
+      world.add({ name: "John", age: 42 })
+      world.add({ name: "Alice" })
+      world.clear()
+      expect(world.entities).toEqual([])
+    })
+
+    it("also removes all entities from known archetypes", () => {
+      const world = new World<{ name: string; age?: number }>()
+      const archetype = world.archetype({ all: ["age"] })
+      const john = world.add({ name: "John", age: 42 })
+      world.add({ name: "Alice" })
+      expect(archetype.entities).toEqual([john])
+      world.clear()
+      expect(archetype.entities).toEqual([])
+    })
+  })
 })

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -10,6 +10,20 @@ describe("World", () => {
       expect(archetype).toBeInstanceOf(Archetype)
     })
 
+    it("returns the same archetype if it already exists", () => {
+      const world = new World<{ name: string; age?: number }>()
+      const archetype1 = world.archetype({ all: ["name"] })
+      const archetype2 = world.archetype({ all: ["name"] })
+      expect(archetype1).toBe(archetype2)
+    })
+
+    it("properly normalizes queries before matching against existing archetypes", () => {
+      const world = new World<{ name: string; age?: number }>()
+      const archetype1 = world.archetype({ all: ["age", "name"] })
+      const archetype2 = world.archetype({ all: ["name", "age"] })
+      expect(archetype1).toBe(archetype2)
+    })
+
     it("adds existing entities that match the query to the archetype", () => {
       const world = new World<{ name: string; age?: number }>()
       const entity = world.add({ name: "John", age: 42 })

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -13,21 +13,21 @@ describe("World", () => {
     it("supports a list of components as a shortcut", () => {
       const world = new World<{ name: string; age?: number }>()
       const archetype1 = world.archetype("name")
-      const archetype2 = world.query({ all: ["name"] })
+      const archetype2 = world.archetype({ all: ["name"] })
       expect(archetype1).toBe(archetype2)
     })
 
     it("returns the same archetype if it already exists", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype1 = world.query({ all: ["name"] })
-      const archetype2 = world.query({ all: ["name"] })
+      const archetype1 = world.archetype({ all: ["name"] })
+      const archetype2 = world.archetype({ all: ["name"] })
       expect(archetype1).toBe(archetype2)
     })
 
     it("properly normalizes queries before matching against existing archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype1 = world.query({ all: ["age", "name"] })
-      const archetype2 = world.query({ all: ["name", "age"] })
+      const archetype1 = world.archetype({ all: ["age", "name"] })
+      const archetype2 = world.archetype({ all: ["name", "age"] })
       expect(archetype1).toBe(archetype2)
     })
 
@@ -36,7 +36,7 @@ describe("World", () => {
       const entity = world.add({ name: "John", age: 42 })
       world.add({ name: "Alice" })
 
-      const archetype = world.query({ all: ["age"] })
+      const archetype = world.archetype({ all: ["age"] })
       expect(archetype.entities).toEqual([entity])
     })
   })
@@ -44,7 +44,7 @@ describe("World", () => {
   describe("add", () => {
     it("adds the entity to matching archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.query({ all: ["age"] })
+      const archetype = world.archetype({ all: ["age"] })
 
       const entity = world.add({ name: "John", age: 42 })
       expect(archetype.entities).toEqual([entity])
@@ -54,7 +54,7 @@ describe("World", () => {
   describe("remove", () => {
     it("removes the entity from all archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.query({ all: ["age"] })
+      const archetype = world.archetype({ all: ["age"] })
 
       const entity = world.add({ name: "John", age: 42 })
       expect(archetype.entities).toEqual([entity])
@@ -81,7 +81,7 @@ describe("World", () => {
 
     it("adds the entity to matching archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.query({ all: ["age"] })
+      const archetype = world.archetype({ all: ["age"] })
       const entity = world.add({ name: "John" })
 
       expect(archetype.entities).toEqual([])
@@ -101,7 +101,7 @@ describe("World", () => {
 
     it("removes the entity from archetype it no longer matches with", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.query({ all: ["age"] })
+      const archetype = world.archetype({ all: ["age"] })
       const entity = world.add({ name: "John", age: 42 })
 
       expect(archetype.entities).toEqual([entity])
@@ -148,7 +148,7 @@ describe("World", () => {
 
     it("also removes all entities from known archetypes", () => {
       const world = new World<{ name: string; age?: number }>()
-      const archetype = world.query({ all: ["age"] })
+      const archetype = world.archetype({ all: ["age"] })
       const john = world.add({ name: "John", age: 42 })
       world.add({ name: "Alice" })
       expect(archetype.entities).toEqual([john])

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -3,11 +3,18 @@ import { World } from "../src/World"
 
 describe("World", () => {
   describe("archetype", () => {
-    it("creates an archetype", () => {
+    it("creates an archetype for the given query", () => {
       const world = new World<{ name: string; age?: number }>()
       const archetype = world.archetype({ all: ["name"] })
       expect(archetype).toBeDefined()
       expect(archetype).toBeInstanceOf(Archetype)
+    })
+
+    it("supports a list of components as a shortcut", () => {
+      const world = new World<{ name: string; age?: number }>()
+      const archetype1 = world.archetype("name")
+      const archetype2 = world.archetype({ all: ["name"] })
+      expect(archetype1).toBe(archetype2)
     })
 
     it("returns the same archetype if it already exists", () => {

--- a/packages/miniplex-core/test/queries.test.ts
+++ b/packages/miniplex-core/test/queries.test.ts
@@ -1,4 +1,8 @@
-import { normalizeComponents, normalizeQuery } from "../src/queries"
+import {
+  normalizeComponents,
+  normalizeQuery,
+  serializeQuery
+} from "../src/queries"
 
 describe("normalizeComponents", () => {
   it("sorts the given list of components alphabetically", () => {
@@ -43,5 +47,17 @@ describe("normalizeQuery", () => {
       any: ["c", "d"],
       none: ["e", "f"]
     })
+  })
+})
+
+describe("serializeQuery", () => {
+  it("serializes the query as JSON", () => {
+    const query = {
+      all: ["a", "b"],
+      any: ["c", "d"],
+      none: ["e", "f"]
+    }
+
+    expect(serializeQuery(query)).toEqual(JSON.stringify(query))
   })
 })

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -97,24 +97,35 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
   const Bucket = memo(RawBucket) as typeof RawBucket
 
   const Archetype = <A extends keyof E>({
-    query,
+    components,
     ...props
   }: {
-    query: A[] | A | Query<E>
+    components: A[] | A
     children?: EntityChildren<WithRequiredComponents<E, A>>
     as?: FunctionComponent<{
       entity: WithRequiredComponents<E, A>
       children?: ReactNode
     }>
-  }) => {
-    const archetype = Array.isArray(query)
-      ? world.archetype(...query)
-      : typeof query === "object"
-      ? world.archetype(query)
-      : world.archetype(query)
+  }) => (
+    <Bucket
+      bucket={world.archetype(
+        ...(Array.isArray(components) ? components : [components])
+      )}
+      {...props}
+    />
+  )
 
-    return <Bucket bucket={archetype} {...props} />
-  }
+  const Query = <D extends keyof E>({
+    query,
+    ...props
+  }: {
+    query: Query<E>
+    children?: EntityChildren<E>
+    as?: FunctionComponent<{
+      entity: E
+      children?: ReactNode
+    }>
+  }) => <Bucket bucket={world.archetype(query)} {...props} />
 
   const Component = <P extends keyof E>(props: {
     name: P
@@ -172,6 +183,7 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
     Entities,
     Bucket,
     Archetype,
+    Query,
     Component,
     useCurrentEntity,
     useArchetype

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -97,27 +97,24 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
 
   const Bucket = memo(RawBucket) as typeof RawBucket
 
-  const Archetype = <
-    D extends WithRequiredComponents<E, C>,
-    C extends keyof E
-  >({
+  const Archetype = <C extends keyof E>({
     query,
     ...props
   }: {
     query: Query<E, C> | C | C[]
-    children?: EntityChildren<D>
+    children?: EntityChildren<WithRequiredComponents<E, C>>
     as?: FunctionComponent<{
-      entity: D
+      entity: WithRequiredComponents<E, C>
       children?: ReactNode
     }>
   }) => (
     <Bucket
       bucket={
-        (Array.isArray(query)
+        Array.isArray(query)
           ? world.archetype(...query)
           : typeof query === "object"
           ? world.archetype(query)
-          : world.archetype(query)) as Archetype<D>
+          : world.archetype(query)
       }
       {...props}
     />

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -115,7 +115,7 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
     />
   )
 
-  const Query = <D extends keyof E>({
+  const Query = ({
     query,
     ...props
   }: {

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -113,7 +113,7 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
       ? world.archetype(query)
       : world.archetype(query)
 
-    return <Bucket bucket={archetype as any} {...props} />
+    return <Bucket bucket={archetype} {...props} />
   }
 
   const Component = <P extends keyof E>(props: {

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -4,7 +4,7 @@ import {
   Bucket,
   IEntity,
   Query,
-  WithRequiredComponents,
+  WithComponents,
   World
 } from "@miniplex/core"
 import React, {
@@ -102,9 +102,9 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
     ...props
   }: {
     query: Query<E, C> | C | C[]
-    children?: EntityChildren<WithRequiredComponents<E, C>>
+    children?: EntityChildren<WithComponents<E, C>>
     as?: FunctionComponent<{
-      entity: WithRequiredComponents<E, C>
+      entity: WithComponents<E, C>
       children?: ReactNode
     }>
   }) => (

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -97,26 +97,10 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
 
   const Bucket = memo(RawBucket) as typeof RawBucket
 
-  const Archetype = <A extends keyof E>({
-    components,
-    ...props
-  }: {
-    components: A[] | A
-    children?: EntityChildren<WithRequiredComponents<E, A>>
-    as?: FunctionComponent<{
-      entity: WithRequiredComponents<E, A>
-      children?: ReactNode
-    }>
-  }) => (
-    <Bucket
-      bucket={world.archetype(
-        ...(Array.isArray(components) ? components : [components])
-      )}
-      {...props}
-    />
-  )
-
-  const Query = <D extends WithRequiredComponents<E, C>, C extends keyof E>({
+  const Archetype = <
+    D extends WithRequiredComponents<E, C>,
+    C extends keyof E
+  >({
     query,
     ...props
   }: {
@@ -195,7 +179,6 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
     Entities,
     Bucket,
     Archetype,
-    Query,
     Component,
     useCurrentEntity,
     useArchetype

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -1,5 +1,6 @@
 import { useConst } from "@hmans/use-const"
 import {
+  Archetype,
   Bucket,
   IEntity,
   Query,
@@ -115,17 +116,17 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
     />
   )
 
-  const Query = ({
+  const Query = <D extends WithRequiredComponents<E, C>, C extends keyof E>({
     query,
     ...props
   }: {
-    query: Query<E>
-    children?: EntityChildren<E>
+    query: Query<E, C>
+    children?: EntityChildren<D>
     as?: FunctionComponent<{
-      entity: E
+      entity: D
       children?: ReactNode
     }>
-  }) => <Bucket bucket={world.archetype(query)} {...props} />
+  }) => <Bucket bucket={world.archetype(query) as Archetype<D>} {...props} />
 
   const Component = <P extends keyof E>(props: {
     name: P

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -1,12 +1,5 @@
 import { useConst } from "@hmans/use-const"
-import {
-  archetype,
-  Bucket,
-  IEntity,
-  Predicate,
-  WithRequiredKeys,
-  World
-} from "@miniplex/core"
+import { Bucket, IEntity, WithRequiredComponents, World } from "@miniplex/core"
 import React, {
   createContext,
   FunctionComponent,
@@ -84,17 +77,14 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
   )
 
   const RawBucket = <D extends E>({
-    bucket: _bucket,
+    bucket,
     ...props
   }: {
-    bucket: Bucket<D> | Predicate<E, D>
+    bucket: Bucket<D>
     children?: EntityChildren<D>
     as?: FunctionComponent<{ entity: D; children?: ReactNode }>
   }) => {
-    const source =
-      typeof _bucket === "function" ? world.derive(_bucket) : _bucket
-
-    const entities = useEntities(source)
+    const entities = useEntities(bucket)
     return <Entities entities={entities} {...props} />
   }
 
@@ -105,14 +95,14 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
     ...props
   }: {
     components: A[] | A
-    children?: EntityChildren<WithRequiredKeys<E, A>>
+    children?: EntityChildren<WithRequiredComponents<E, A>>
     as?: FunctionComponent<{
-      entity: WithRequiredKeys<E, A>
+      entity: WithRequiredComponents<E, A>
       children?: ReactNode
     }>
   }) => (
     <Bucket
-      bucket={archetype(
+      bucket={world.archetype(
         ...(Array.isArray(components) ? components : [components])
       )}
       {...props}
@@ -144,7 +134,7 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
     /* Handle updates to existing component */
     useIsomorphicLayoutEffect(() => {
       if (props.value === undefined) return
-      world.setComponent(entity, props.name, props.value)
+      entity[props.name] = props.value
     }, [entity, props.name, props.value])
 
     /* Handle setting of child value */

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -120,13 +120,24 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
     query,
     ...props
   }: {
-    query: Query<E, C>
+    query: Query<E, C> | C | C[]
     children?: EntityChildren<D>
     as?: FunctionComponent<{
       entity: D
       children?: ReactNode
     }>
-  }) => <Bucket bucket={world.archetype(query) as Archetype<D>} {...props} />
+  }) => (
+    <Bucket
+      bucket={
+        (Array.isArray(query)
+          ? world.archetype(...query)
+          : typeof query === "object"
+          ? world.archetype(query)
+          : world.archetype(query)) as Archetype<D>
+      }
+      {...props}
+    />
+  )
 
   const Component = <P extends keyof E>(props: {
     name: P

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -1,5 +1,11 @@
 import { useConst } from "@hmans/use-const"
-import { Bucket, IEntity, WithRequiredComponents, World } from "@miniplex/core"
+import {
+  Bucket,
+  IEntity,
+  Query,
+  WithRequiredComponents,
+  World
+} from "@miniplex/core"
 import React, {
   createContext,
   FunctionComponent,
@@ -91,23 +97,24 @@ export const createReactAPI = <E extends IEntity>(world: World<E>) => {
   const Bucket = memo(RawBucket) as typeof RawBucket
 
   const Archetype = <A extends keyof E>({
-    components,
+    query,
     ...props
   }: {
-    components: A[] | A
+    query: A[] | A | Query<E>
     children?: EntityChildren<WithRequiredComponents<E, A>>
     as?: FunctionComponent<{
       entity: WithRequiredComponents<E, A>
       children?: ReactNode
     }>
-  }) => (
-    <Bucket
-      bucket={world.archetype(
-        ...(Array.isArray(components) ? components : [components])
-      )}
-      {...props}
-    />
-  )
+  }) => {
+    const archetype = Array.isArray(query)
+      ? world.archetype(...query)
+      : typeof query === "object"
+      ? world.archetype(query)
+      : world.archetype(query)
+
+    return <Bucket bucket={archetype as any} {...props} />
+  }
 
   const Component = <P extends keyof E>(props: {
     name: P

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -1,12 +1,5 @@
 import { useConst } from "@hmans/use-const"
-import {
-  Archetype,
-  Bucket,
-  IEntity,
-  Query,
-  WithComponents,
-  World
-} from "@miniplex/core"
+import { Bucket, IEntity, Query, WithComponents, World } from "@miniplex/core"
 import React, {
   createContext,
   FunctionComponent,

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom"
 import { act, render, renderHook, screen } from "@testing-library/react"
-import { all, World } from "@miniplex/core"
+import { World } from "@miniplex/core"
 import React from "react"
 import createReactAPI from "../src"
 
@@ -348,7 +348,7 @@ describe("<Query>", () => {
     world.add({ name: "Bob", age: 100 })
 
     render(
-      <Query query={all("name").query}>
+      <Query query={{ all: ["name"] }}>
         {(entity) => <p>{entity.name}</p>}
       </Query>
     )

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -285,9 +285,7 @@ describe("<Archetype>", () => {
     world.add({ name: "Bob" })
 
     render(
-      <Archetype components="name">
-        {(entity) => <p>{entity.name}</p>}
-      </Archetype>
+      <Archetype query="name">{(entity) => <p>{entity.name}</p>}</Archetype>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()
@@ -301,10 +299,8 @@ describe("<Archetype>", () => {
     world.add({ name: "Alice" })
     world.add({ name: "Bob" })
 
-    const { rerender } = render(
-      <Archetype components="name">
-        {(entity) => <p>{entity.name}</p>}
-      </Archetype>
+    render(
+      <Archetype query="name">{(entity) => <p>{entity.name}</p>}</Archetype>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()
@@ -330,11 +326,28 @@ describe("<Archetype>", () => {
 
       const User = (props: { entity: Entity }) => <div>{props.entity.name}</div>
 
-      render(<Archetype as={User} components="name" />)
+      render(<Archetype as={User} query="name" />)
 
       expect(screen.getByText("Alice")).toBeInTheDocument()
       expect(screen.getByText("Bob")).toBeInTheDocument()
     })
+  })
+
+  it("accepts a query object as its `query` prop", () => {
+    const world = new World<{ name: string; age?: number }>()
+    const { Archetype } = createReactAPI(world)
+
+    world.add({ name: "Alice" })
+    world.add({ name: "Bob" })
+
+    render(
+      <Archetype query={{ all: ["name"] }}>
+        {(entity) => <p>{entity.name}</p>}
+      </Archetype>
+    )
+
+    expect(screen.getByText("Alice")).toBeInTheDocument()
+    expect(screen.getByText("Bob")).toBeInTheDocument()
   })
 })
 

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -348,7 +348,9 @@ describe("<Query>", () => {
     world.add({ name: "Bob", age: 100 })
 
     render(
-      <Query query={all("name")}>{(entity) => <p>{entity.name}</p>}</Query>
+      <Query query={all("name").query}>
+        {(entity) => <p>{entity.name}</p>}
+      </Query>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -285,9 +285,7 @@ describe("<Archetype>", () => {
     world.add({ name: "Bob" })
 
     render(
-      <Archetype components="name">
-        {(entity) => <p>{entity.name}</p>}
-      </Archetype>
+      <Archetype query="name">{(entity) => <p>{entity.name}</p>}</Archetype>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()
@@ -302,9 +300,7 @@ describe("<Archetype>", () => {
     world.add({ name: "Bob" })
 
     render(
-      <Archetype components="name">
-        {(entity) => <p>{entity.name}</p>}
-      </Archetype>
+      <Archetype query="name">{(entity) => <p>{entity.name}</p>}</Archetype>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()
@@ -330,27 +326,25 @@ describe("<Archetype>", () => {
 
       const User = (props: { entity: Entity }) => <div>{props.entity.name}</div>
 
-      render(<Archetype as={User} components="name" />)
+      render(<Archetype as={User} query="name" />)
 
       expect(screen.getByText("Alice")).toBeInTheDocument()
       expect(screen.getByText("Bob")).toBeInTheDocument()
     })
   })
-})
 
-describe("<Query>", () => {
   it("accepts a query object as its `query` prop", () => {
     type Entity = { name: string; age?: number }
     const world = new World<Entity>()
-    const { Query } = createReactAPI(world)
+    const { Archetype } = createReactAPI(world)
 
     world.add({ name: "Alice" })
     world.add({ name: "Bob", age: 100 })
 
     render(
-      <Query query={{ all: ["name"] }}>
+      <Archetype query={{ all: ["name"] }}>
         {(entity) => <p>{entity.name}</p>}
-      </Query>
+      </Archetype>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -344,7 +344,7 @@ describe("<Query>", () => {
     const { Query } = createReactAPI(world)
 
     world.add({ name: "Alice" })
-    world.add({ name: "Bob" })
+    world.add({ name: "Bob", age: 100 })
 
     render(
       <Query query={{ all: ["name"] }}>

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -293,7 +293,7 @@ describe("<Archetype>", () => {
   })
 
   it("re-renders the entities when the bucket contents change", () => {
-    const world = new World<{ name: string }>()
+    const world = new World<{ name: string; age?: number }>()
     const { Archetype } = createReactAPI(world)
 
     world.add({ name: "Alice" })

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom"
 import { act, render, renderHook, screen } from "@testing-library/react"
-import { World } from "@miniplex/core"
+import { all, World } from "@miniplex/core"
 import React from "react"
 import createReactAPI from "../src"
 
@@ -340,16 +340,15 @@ describe("<Archetype>", () => {
 
 describe("<Query>", () => {
   it("accepts a query object as its `query` prop", () => {
-    const world = new World<{ name: string; age?: number }>()
+    type Entity = { name: string; age?: number }
+    const world = new World<Entity>()
     const { Query } = createReactAPI(world)
 
     world.add({ name: "Alice" })
     world.add({ name: "Bob", age: 100 })
 
     render(
-      <Query query={{ all: ["name"] }}>
-        {(entity) => <p>{entity.name}</p>}
-      </Query>
+      <Query query={all("name")}>{(entity) => <p>{entity.name}</p>}</Query>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -285,7 +285,9 @@ describe("<Archetype>", () => {
     world.add({ name: "Bob" })
 
     render(
-      <Archetype query="name">{(entity) => <p>{entity.name}</p>}</Archetype>
+      <Archetype components="name">
+        {(entity) => <p>{entity.name}</p>}
+      </Archetype>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()
@@ -300,7 +302,9 @@ describe("<Archetype>", () => {
     world.add({ name: "Bob" })
 
     render(
-      <Archetype query="name">{(entity) => <p>{entity.name}</p>}</Archetype>
+      <Archetype components="name">
+        {(entity) => <p>{entity.name}</p>}
+      </Archetype>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()
@@ -326,24 +330,26 @@ describe("<Archetype>", () => {
 
       const User = (props: { entity: Entity }) => <div>{props.entity.name}</div>
 
-      render(<Archetype as={User} query="name" />)
+      render(<Archetype as={User} components="name" />)
 
       expect(screen.getByText("Alice")).toBeInTheDocument()
       expect(screen.getByText("Bob")).toBeInTheDocument()
     })
   })
+})
 
+describe("<Query>", () => {
   it("accepts a query object as its `query` prop", () => {
     const world = new World<{ name: string; age?: number }>()
-    const { Archetype } = createReactAPI(world)
+    const { Query } = createReactAPI(world)
 
     world.add({ name: "Alice" })
     world.add({ name: "Bob" })
 
     render(
-      <Archetype query={{ all: ["name"] }}>
+      <Query query={{ all: ["name"] }}>
         {(entity) => <p>{entity.name}</p>}
-      </Archetype>
+      </Query>
     )
 
     expect(screen.getByText("Alice")).toBeInTheDocument()

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -232,7 +232,7 @@ describe("<Bucket>", () => {
     const world = new World<{ name: string }>()
     const { Bucket } = createReactAPI(world)
 
-    world.add({ name: "Alice" })
+    const alice = world.add({ name: "Alice" })
     world.add({ name: "Bob" })
 
     render(<Bucket bucket={world}>{(entity) => <p>{entity.name}</p>}</Bucket>)
@@ -245,6 +245,14 @@ describe("<Bucket>", () => {
     })
 
     expect(screen.getByText("Alice")).toBeInTheDocument()
+    expect(screen.getByText("Bob")).toBeInTheDocument()
+    expect(screen.getByText("Charlie")).toBeInTheDocument()
+
+    act(() => {
+      world.remove(alice)
+    })
+
+    expect(screen.queryByText("Alice")).toBeNull()
     expect(screen.getByText("Bob")).toBeInTheDocument()
     expect(screen.getByText("Charlie")).toBeInTheDocument()
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
-    "module": "ES2015",
+    "target": "esnext",
+    "module": "esnext",
     "moduleResolution": "node",
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
Making world a little bit smarter about archetypes and queries.

#### Checklist

- [x] Refactor the core library to teach the `World` some more smarts about archetypes
- [x] Allow the `world.archetype("foo", "bar")` shortcut
- [x] Correct typing of `add`
- [x] Apply performance optimizations
- [x] Check if the React library still works
- [x] `bucket.clear()` and `world.clear()`
- [x] ~Allow the user to provide a type for archetypes~ Just cast them
- [x] `id` and `entity`
- [x] `<ECS.Archetype query={queryObject} />`