### PR TITLE
Remove `as`

### DIFF
--- a/.changeset/warm-kids-provide.md
+++ b/.changeset/warm-kids-provide.md
@@ -1,0 +1,21 @@
+---
+"@miniplex/react": patch
+---
+
+**Breaking Change:** Removed the `as` prop. Please use `children` instead:
+
+```tsx
+/* A function component whose props signature matches the entity type */
+const User = ({ name }: { name: string }) => <div>{name}</div>
+
+/* Pass it directly into the `children` prop */
+<Entity in={users} children={User} />
+```
+
+As a reminder, this sort of `children` prop support isn't new; Miniplex has always supported this form:
+
+```tsx
+<Entity in={users}>{(user) => <div>{user.name}</div>}</Entity>
+```
+
+Passing a `children` prop is just another way to pass children to a React component.

--- a/apps/demo/src/entities/Asteroids.tsx
+++ b/apps/demo/src/entities/Asteroids.tsx
@@ -47,10 +47,10 @@ export const Asteroids = () => {
       </Composable.MeshStandardMaterial>
 
       {segmentedAsteroids.entities.map((segment, i) => (
-        <ECS.Entities key={i} in={segment} as={RenderableEntity} />
+        <ECS.Entities key={i} in={segment} children={RenderableEntity} />
       ))}
 
-      {/* <ECS.Entities bucket={asteroids} as={RenderableEntity} /> */}
+      {/* <ECS.Entities bucket={asteroids} children={RenderableEntity} /> */}
     </InstancedParticles>
   )
 }

--- a/apps/demo/src/entities/Bullets.tsx
+++ b/apps/demo/src/entities/Bullets.tsx
@@ -12,7 +12,7 @@ export const Bullets = () => (
     <planeGeometry args={[0.15, 0.5]} />
     <meshStandardMaterial color={new Color("orange").multiplyScalar(5)} />
 
-    <ECS.Archetype with="isBullet" as={RenderableEntity} />
+    <ECS.Archetype with="isBullet" children={RenderableEntity} />
   </InstancedParticles>
 )
 

--- a/apps/demo/src/entities/RenderableEntity.tsx
+++ b/apps/demo/src/entities/RenderableEntity.tsx
@@ -1,5 +1,3 @@
 import { Entity } from "../state"
 
-export const RenderableEntity = (props: { entity: Pick<Entity, "render"> }) => (
-  <>{props.entity.render}</>
-)
+export const RenderableEntity = ({ render }: Pick<Entity, "render">) => render!

--- a/apps/demo/src/state.ts
+++ b/apps/demo/src/state.ts
@@ -57,7 +57,7 @@ export type Entity = {
   /* Simulate physics. */
   physics?: PhysicsData
 
-  render?: JSX.Element
+  render?: ReactNode
 }
 
 export type Asteroid = With<

--- a/apps/demo/src/state.ts
+++ b/apps/demo/src/state.ts
@@ -57,7 +57,7 @@ export type Entity = {
   /* Simulate physics. */
   physics?: PhysicsData
 
-  render?: ReactNode
+  render?: JSX.Element
 }
 
 export type Asteroid = With<

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -17,7 +17,7 @@ import { mergeRefs } from "./lib/mergeRefs"
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect
 
-export type EntityChildren<E> = JSX.Element | FunctionComponent<E>
+export type EntityChildren<E> = ReactElement | FunctionComponent<E>
 
 type CommonProps<E> = {
   children?: EntityChildren<E>

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -17,16 +17,10 @@ import { mergeRefs } from "./lib/mergeRefs"
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect
 
-export type EntityChildren<E> = ReactNode | ((entity: E) => ReactNode)
-
-type AsComponent<E> = FunctionComponent<{
-  entity: E
-  children?: ReactNode
-}>
+export type EntityChildren<E> = JSX.Element | FunctionComponent<E>
 
 type CommonProps<E> = {
   children?: EntityChildren<E>
-  as?: AsComponent<E>
 }
 
 export const createReactAPI = <E,>(world: World<E>) => {
@@ -36,8 +30,7 @@ export const createReactAPI = <E,>(world: World<E>) => {
 
   const RawEntity = <D extends E>({
     children: givenChildren,
-    entity = {} as D,
-    as: As
+    entity = {} as D
   }: CommonProps<D> & {
     entity?: D
   }) => {
@@ -57,9 +50,7 @@ export const createReactAPI = <E,>(world: World<E>) => {
         : givenChildren
 
     return (
-      <EntityContext.Provider value={entity}>
-        {As ? <As entity={entity}>{children}</As> : children}
-      </EntityContext.Provider>
+      <EntityContext.Provider value={entity}>{children}</EntityContext.Provider>
     )
   }
 

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -1,7 +1,6 @@
 import { Bucket, With, World } from "@miniplex/core"
 import React, {
   createContext,
-  FunctionComponent,
   memo,
   ReactElement,
   ReactNode,
@@ -17,7 +16,7 @@ import { mergeRefs } from "./lib/mergeRefs"
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect
 
-export type EntityChildren<E> = ReactElement | FunctionComponent<E>
+export type EntityChildren<E> = ReactNode | ((entity: E) => ReactNode)
 
 type CommonProps<E> = {
   children?: EntityChildren<E>

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -81,18 +81,16 @@ describe("<Entity>", () => {
     })
   })
 
-  describe("given an `as` prop", () => {
+  describe("given `children` prop", () => {
     it("renders the entity using that component, passing the entity to it", () => {
       const world = new World<Entity>()
       const { Entity } = createReactAPI(world)
 
       const entity = world.add({ name: "John" })
 
-      const Person = (props: { entity: Entity }) => (
-        <div>{props.entity.name}</div>
-      )
+      const Person = ({ name }: { name: string }) => <div>{name}</div>
 
-      render(<Entity as={Person} entity={entity} />)
+      render(<Entity entity={entity} children={Person} />)
 
       expect(screen.getByText("John")).toBeInTheDocument()
     })
@@ -252,7 +250,7 @@ describe("<Entities>", () => {
     })
   })
 
-  describe("given an `as` prop", () => {
+  describe("given an `children` prop", () => {
     it("renders the entities using the given component, passing the entity to it", () => {
       const world = new World<Entity>()
       const { Entities } = createReactAPI(world)
@@ -260,9 +258,9 @@ describe("<Entities>", () => {
       world.add({ name: "Alice" })
       world.add({ name: "Bob" })
 
-      const User = (props: { entity: Entity }) => <div>{props.entity.name}</div>
+      const User = ({ name }: { name: string }) => <div>{name}</div>
 
-      render(<Entities in={world} as={User} />)
+      render(<Entities in={world} children={User} />)
 
       expect(screen.getByText("Alice")).toBeInTheDocument()
       expect(screen.getByText("Bob")).toBeInTheDocument()
@@ -309,7 +307,7 @@ describe("<Archetype>", () => {
     expect(screen.getByText("Alice")).toBeInTheDocument()
   })
 
-  describe("given an `as` prop", () => {
+  describe("given a `children` prop", () => {
     it("renders the entities using the given component, passing the entity to it", () => {
       const world = new World<Entity>()
       const { Archetype } = createReactAPI(world)
@@ -318,9 +316,9 @@ describe("<Archetype>", () => {
       world.add({ name: "Alice" })
       world.add({ name: "Charlie", age: 32, height: 180 })
 
-      const User = (props: { entity: Entity }) => <div>{props.entity.name}</div>
+      const User = ({ name }: { name: string }) => <div>{name}</div>
 
-      render(<Archetype with="age" as={User} />)
+      render(<Archetype with="age" children={User} />)
 
       expect(screen.getByText("John")).toBeInTheDocument()
       expect(screen.queryByText("Alice")).toBeNull()


### PR DESCRIPTION
The overlap between `as` and `children` was just too signficant.