### PR TITLE
Allow `remove` to remove many entities at once

### DIFF
--- a/.changeset/happy-parents-relax.md
+++ b/.changeset/happy-parents-relax.md
@@ -1,0 +1,5 @@
+---
+"@miniplex/bucket": patch
+---
+
+`remove` can now also take an iterable as its argument, removing all entities contained within.

--- a/apps/demo/src/entities/Asteroids.tsx
+++ b/apps/demo/src/entities/Asteroids.tsx
@@ -28,9 +28,7 @@ export const Asteroids = () => {
     }
 
     return () => {
-      for (const asteroid of archetypes.asteroids) {
-        ECS.world.remove(asteroid)
-      }
+      ECS.world.remove(archetypes.asteroids)
     }
   }, [])
 

--- a/packages/miniplex-bucket/src/Bucket.ts
+++ b/packages/miniplex-bucket/src/Bucket.ts
@@ -1,4 +1,5 @@
 import { Event } from "@hmans/event"
+import { isIterable } from "./util/isIterable"
 
 /**
  * A class wrapping an array of entities of a specific type, providing
@@ -84,9 +85,20 @@ export class Bucket<E> implements Iterable<E> {
    * happens.
    *
    * @param entity The entity to remove from the bucket.
-   * @returns The entity passed into this function (regardless of whether it was removed or not).
    */
-  remove(entity: E) {
+  remove<D extends E>(entity: D): void
+
+  /**
+   *
+   * @param entities An `Iterable` of entities to remove from the bucket.
+   */
+  remove(entities: Iterable<E>): void
+
+  remove(entity: E | Iterable<E>) {
+    if (isIterable(entity)) {
+      for (const e of entity) this.remove(e)
+    }
+
     if (this.has(entity)) {
       /* Emit our own onEntityRemoved event. */
       this.onEntityRemoved.emit(entity)
@@ -105,8 +117,6 @@ export class Bucket<E> implements Iterable<E> {
       /* Remove the entity from the entities array. */
       this.entities.pop()
     }
-
-    return entity
   }
 
   /**

--- a/packages/miniplex-bucket/src/util/isIterable.ts
+++ b/packages/miniplex-bucket/src/util/isIterable.ts
@@ -1,0 +1,3 @@
+export function isIterable<T>(value: any): value is Iterable<T> {
+  return value != null && typeof value[Symbol.iterator] === "function"
+}

--- a/packages/miniplex-bucket/test/Bucket.test.ts
+++ b/packages/miniplex-bucket/test/Bucket.test.ts
@@ -63,15 +63,6 @@ describe(Bucket, () => {
       expect(bucket.entities).not.toContain(entity)
     })
 
-    it("returns the entity", () => {
-      const bucket = new Bucket()
-      const entity = { id: "1" }
-
-      const result = bucket.remove(entity)
-
-      expect(result).toBe(entity)
-    })
-
     it("emits the onEntityRemoved event", () => {
       const bucket = new Bucket()
       const entity = bucket.add({ id: "1" })
@@ -81,6 +72,16 @@ describe(Bucket, () => {
       bucket.remove(entity)
 
       expect(listener).toHaveBeenCalledWith(entity)
+    })
+
+    it("can remove all entities from an iterable", () => {
+      const bucket = new Bucket()
+      const entity1 = bucket.add({ id: "1" })
+      const entity2 = bucket.add({ id: "2" })
+
+      bucket.remove([entity1, entity2])
+
+      expect(bucket.entities).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
Allows `world.remove(manyEntities)`, where `manyEntities` can by any iterable (ie. an array, a bucket, ...)