### PR TITLE
[Experimental] Nullify removed entities

### DIFF
--- a/packages/miniplex-bucket/src/Bucket.ts
+++ b/packages/miniplex-bucket/src/Bucket.ts
@@ -12,7 +12,12 @@ export class Bucket<E> implements Iterable<E> {
 
     return {
       next: () => {
-        const value = this.entities[--index]
+        let value: E | null = null
+
+        do {
+          value = this.entities[--index]
+        } while (value === null && index >= 0)
+
         return { value, done: index < 0 }
       }
     }
@@ -47,7 +52,7 @@ export class Bucket<E> implements Iterable<E> {
    * Returns the total size of the bucket, i.e. the number of entities it contains.
    */
   get size() {
-    return this.entities.length
+    return this.entityPositions.size
   }
 
   /**
@@ -95,15 +100,10 @@ export class Bucket<E> implements Iterable<E> {
       const index = this.entityPositions.get(entity)!
       this.entityPositions.delete(entity)
 
-      /* Perform shuffle-pop if there is more than one entity. */
-      const other = this.entities[this.entities.length - 1]
-      if (other !== entity) {
-        this.entities[index] = other
-        this.entityPositions.set(other, index)
-      }
+      /* Null the entry */
+      this.entities[index] = null as any
 
-      /* Remove the entity from the entities array. */
-      this.entities.pop()
+      /* Maybe TODO: track the freed position so we can reuse it */
     }
 
     return entity

--- a/packages/miniplex-bucket/test/Bucket.test.ts
+++ b/packages/miniplex-bucket/test/Bucket.test.ts
@@ -82,6 +82,21 @@ describe(Bucket, () => {
 
       expect(listener).toHaveBeenCalledWith(entity)
     })
+
+    it("nulls the entity's entry in the entities array", () => {
+      const bucket = new Bucket()
+      const entity = bucket.add({ id: "1" })
+      bucket.remove(entity)
+      expect(bucket.entities).toEqual([null])
+    })
+
+    it("doesn't yield nulled entried when iterating", () => {
+      const bucket = new Bucket()
+      const entity = bucket.add({ id: "1" })
+      bucket.remove(entity)
+      expect(bucket.entities).toEqual([null])
+      expect([...bucket]).toEqual([])
+    })
   })
 
   describe("size", () => {

--- a/packages/miniplex-core/benchmark.ts
+++ b/packages/miniplex-core/benchmark.ts
@@ -91,7 +91,7 @@ profile("remove (random)", () => {
   return () => {
     while (world.size > 0) {
       /* Get a random entity... */
-      const entity = world.entities[Math.floor(Math.random() * world.size)]
+      const [entity] = world
 
       /* ...and delete it */
       world.remove(entity)
@@ -115,7 +115,7 @@ profile("remove (random, with archetypes)", () => {
   return () => {
     while (world.size > 0) {
       /* Get a random entity... */
-      const entity = world.entities[Math.floor(Math.random() * world.size)]
+      const [entity] = world
 
       /* ...and delete it */
       world.remove(entity)

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -30,7 +30,7 @@ describe(World, () => {
       expect(world.entities).toEqual([entity])
 
       world.remove(entity)
-      expect(world.entities).toEqual([])
+      expect([...world]).toEqual([])
     })
   })
 
@@ -81,8 +81,8 @@ describe(World, () => {
       const jane = world.add({ name: "Jane" })
 
       world.addComponent(john, "age", 30)
-      expect(withAge.entities).toEqual([john])
-      expect(withoutAge.entities).toEqual([jane])
+      expect([...withAge]).toEqual([john])
+      expect([...withoutAge]).toEqual([jane])
     })
 
     it("adds the entity to nested archetypes", () => {
@@ -113,7 +113,7 @@ describe(World, () => {
       expect(withAge.entities).toEqual([john, jane])
 
       world.removeComponent(john, "age")
-      expect(withAge.entities).toEqual([jane])
+      expect([...withAge]).toEqual([jane])
     })
 
     it("removes the entity from nested archetypes", () => {
@@ -124,7 +124,7 @@ describe(World, () => {
       expect(withAge.entities).toEqual([john])
 
       world.removeComponent(john, "age")
-      expect(withAge.entities).toEqual([])
+      expect([...withAge]).toEqual([])
     })
 
     it("uses a future check, so in onEntityRemoved, the entity is still intact", () => {

--- a/packages/miniplex-core/test/buckets.test.ts
+++ b/packages/miniplex-core/test/buckets.test.ts
@@ -116,11 +116,11 @@ describe(EntityBucket, () => {
 
           john.age = 25
           old.update()
-          expect(old.entities).toEqual([])
+          expect([...old]).toEqual([])
 
           john.age = 30
           old.update()
-          expect(old.entities).toEqual([john])
+          expect([...old]).toEqual([john])
         })
       })
     })
@@ -142,11 +142,11 @@ describe(EntityBucket, () => {
 
       delete entity.age
       bucket.evaluate(entity)
-      expect(withAge.entities).toEqual([])
+      expect([...withAge]).toEqual([])
 
       entity.age = 30
       bucket.evaluate(entity)
-      expect(withAge.entities).toEqual([entity])
+      expect([...withAge]).toEqual([entity])
     })
   })
 
@@ -210,7 +210,7 @@ describe(EntityBucket, () => {
       expect(bucket.entities).toEqual([entity])
 
       bucket.remove(entity)
-      expect(bucket.entities).toEqual([])
+      expect([...bucket]).toEqual([])
     })
 
     it("removes the entity from any relevant archetypes", () => {
@@ -220,7 +220,7 @@ describe(EntityBucket, () => {
       expect(archetype.entities).toEqual([entity])
 
       bucket.remove(entity)
-      expect(archetype.entities).toEqual([])
+      expect([...archetype]).toEqual([])
     })
   })
 })

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -62,9 +62,10 @@ export const createReactAPI = <E,>(world: World<E>) => {
     entities: D[]
   }) => (
     <>
-      {entities.map((entity) => (
-        <Entity key={world.id(entity)} entity={entity} {...props} />
-      ))}
+      {entities.map(
+        (entity) =>
+          entity && <Entity key={world.id(entity)} entity={entity} {...props} />
+      )}
     </>
   )
 

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -15,9 +15,9 @@ describe("<Entity>", () => {
     const world = new World<Entity>()
     const { Entity } = createReactAPI(world)
 
-    expect(world.entities.length).toBe(0)
+    expect(world.size).toBe(0)
     render(<Entity />)
-    expect(world.entities.length).toBe(1)
+    expect(world.size).toBe(1)
   })
 
   it("removes the entity on unmount", () => {
@@ -25,9 +25,9 @@ describe("<Entity>", () => {
     const { Entity } = createReactAPI(world)
 
     const { unmount } = render(<Entity />)
-    expect(world.entities.length).toBe(1)
+    expect(world.size).toBe(1)
     unmount()
-    expect(world.entities.length).toBe(0)
+    expect(world.size).toBe(0)
   })
 
   it("accepts a function as its child", () => {
@@ -63,9 +63,9 @@ describe("<Entity>", () => {
       const { Entity } = createReactAPI(world)
       const entity = { name: "John" }
 
-      expect(world.entities.length).toBe(0)
+      expect(world.size).toBe(0)
       render(<Entity entity={entity} />)
-      expect(world.entities.length).toBe(1)
+      expect(world.size).toBe(1)
       expect(world.entities[0]).toBe(entity)
     })
 
@@ -75,9 +75,9 @@ describe("<Entity>", () => {
       const entity = { name: "John" }
 
       const { unmount } = render(<Entity entity={entity} />)
-      expect(world.entities.length).toBe(1)
+      expect(world.size).toBe(1)
       unmount()
-      expect(world.entities.length).toBe(0)
+      expect(world.size).toBe(0)
     })
   })
 
@@ -120,14 +120,14 @@ describe("<Component>", () => {
         <Component name="name" data="John" />
       </Entity>
     )
-    expect(world.entities[0].name).toBe("John")
+    expect([...world]).toEqual([{ name: "John" }])
 
     rerender(
       <Entity>
         <Component name="name" data="Jane" />
       </Entity>
     )
-    expect(world.entities[0].name).toBe("Jane")
+    expect([...world]).toEqual([{ name: "Jane" }])
   })
 
   it("removes the component when the component is unmounted", () => {


### PR DESCRIPTION
This PR changes how buckets handle entity removals by nullifying their entries from the `entities` array. The bucket iterator has been changed to skip nulled entries.

- [x] Nullify removed entities in `entities`
- [x] Change iterator to skip these nullified entries
- [x] Skip nullified entities in the React glue
- [ ] Re-use nullified spots
- [ ] Offer a `compact` function that compacts the entities array
- [ ] Maybe make `entities` private?