### PR TITLE
`world.update`

### DIFF
--- a/.changeset/thick-zoos-watch.md
+++ b/.changeset/thick-zoos-watch.md
@@ -1,0 +1,25 @@
+---
+"@miniplex/core": patch
+---
+
+Added an `update` function to the `World` class that allows the user to update an entity. This is intended to complement the other two mutating functions (`addComponent`, `removeComponent`), simply to allow for the use of syntactic sugar (component constructor functions, entity factories, etc.) in a streamlined fashion:
+
+```js
+/* With an object with changes */
+world.update(entity, { age: entity.age + 1 })
+
+/* With a function returning an object with changes */
+const increaseAge = ({age}) => ({ age: age + 1 }
+world.update(entity, increaseAge)
+
+/* With a function that mutates the entity directly: */
+const mutatingIncreaseAge = (entity) => entity.age++
+world.update(entity, mutatingIncreaseAge)
+```
+
+The main job of the function is to re-index the updated entity against known derived buckets, and since in Miniplex you'll typically mutate entities directly, it can even be called with _only_ an entity. All of the above are essentially equivalent to:
+
+```js
+entity.age++
+world.update(entity)
+```

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -15,11 +15,17 @@ export class World<E extends {} = any> extends EntityBucket<E> {
     })
   }
 
+  update(entity: E): E
+
   update(entity: E, update: Partial<E>): E
 
-  update(entity: E, update: Partial<E>) {
+  update(entity: E, fun: (entity: E) => Partial<E> | void): E
+
+  update(entity: E, update?: Partial<E> | ((entity: E) => Partial<E> | void)) {
+    const changes = typeof update === "function" ? update(entity) : update
+
     /* Update the entity. */
-    Object.assign(entity, update)
+    if (changes) Object.assign(entity, changes)
 
     /* If this world knows about the entity, notify any derived buckets about the change. */
     if (this.has(entity)) {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -1,6 +1,6 @@
 import { EntityBucket } from "./buckets"
 
-export class World<E = any> extends EntityBucket<E> {
+export class World<E extends {} = any> extends EntityBucket<E> {
   constructor(entities: E[] = []) {
     super(entities)
 
@@ -13,6 +13,16 @@ export class World<E = any> extends EntityBucket<E> {
         this.entityToId.delete(entity)
       }
     })
+  }
+
+  update(entity: E, update: Partial<E>) {
+    /* Update the entity. */
+    Object.assign(entity, update)
+
+    /* If this world knows about the entity, notify any derived buckets about the change. */
+    if (this.has(entity)) {
+      this.evaluate(entity)
+    }
   }
 
   addComponent<C extends keyof E>(entity: E, component: C, value: E[C]) {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -17,15 +17,25 @@ export class World<E extends {} = any> extends EntityBucket<E> {
 
   update(entity: E): E
 
+  update<C extends keyof E>(entity: E, component: C, value: E[C]): E
+
   update(entity: E, update: Partial<E>): E
 
   update(entity: E, fun: (entity: E) => Partial<E> | void): E
 
-  update(entity: E, update?: Partial<E> | ((entity: E) => Partial<E> | void)) {
-    const changes = typeof update === "function" ? update(entity) : update
-
-    /* Update the entity. */
-    if (changes) Object.assign(entity, changes)
+  update(
+    entity: E,
+    update?: Partial<E> | keyof E | ((entity: E) => Partial<E> | void),
+    value?: any
+  ) {
+    if (typeof update === "function") {
+      const partial = update(entity)
+      partial && Object.assign(entity, partial)
+    } else if (typeof update === "string") {
+      entity[update] = value
+    } else if (update) {
+      Object.assign(entity, update)
+    }
 
     /* If this world knows about the entity, notify any derived buckets about the change. */
     if (this.has(entity)) {

--- a/packages/miniplex-core/src/World.ts
+++ b/packages/miniplex-core/src/World.ts
@@ -15,6 +15,8 @@ export class World<E extends {} = any> extends EntityBucket<E> {
     })
   }
 
+  update(entity: E, update: Partial<E>): E
+
   update(entity: E, update: Partial<E>) {
     /* Update the entity. */
     Object.assign(entity, update)
@@ -23,6 +25,8 @@ export class World<E extends {} = any> extends EntityBucket<E> {
     if (this.has(entity)) {
       this.evaluate(entity)
     }
+
+    return entity
   }
 
   addComponent<C extends keyof E>(entity: E, component: C, value: E[C]) {

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -61,6 +61,39 @@ describe(World, () => {
       const entity = world.add({ name: "John" })
       expect(world.update(entity, { name: "Jane" })).toEqual(entity)
     })
+
+    it("accepts a function that returns a change object", () => {
+      const world = new World<Entity>()
+      const entity = world.add({ name: "John" })
+      expect(entity.name).toEqual("John")
+
+      world.update(entity, () => ({ name: "Jane" }))
+      expect(entity.name).toEqual("Jane")
+    })
+
+    it("accepts a function that mutates the entity directly", () => {
+      const world = new World<Entity>()
+      const entity = world.add({ name: "John" })
+      expect(entity.name).toEqual("John")
+
+      world.update(entity, (entity) => {
+        entity.name = "Jane"
+      })
+      expect(entity.name).toEqual("Jane")
+    })
+
+    it("can be called without a second argument to trigger the reindexing only", () => {
+      const world = new World<Entity>()
+      const entity = world.add({ name: "John" })
+      expect(entity.name).toEqual("John")
+
+      const hasAge = world.archetype("age")
+      expect(hasAge.entities).toEqual([])
+
+      entity.age = 45
+      world.update(entity)
+      expect(hasAge.entities).toEqual([entity])
+    })
   })
 
   describe("id", () => {

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -82,6 +82,15 @@ describe(World, () => {
       expect(entity.name).toEqual("Jane")
     })
 
+    it("accepts a component name and value", () => {
+      const world = new World<Entity>()
+      const entity = world.add({ name: "John" })
+      expect(entity.name).toEqual("John")
+
+      world.update(entity, "name", "Jane")
+      expect(entity.name).toEqual("Jane")
+    })
+
     it("can be called without a second argument to trigger the reindexing only", () => {
       const world = new World<Entity>()
       const entity = world.add({ name: "John" })

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -34,6 +34,29 @@ describe(World, () => {
     })
   })
 
+  describe("update", () => {
+    it("updates the entity", () => {
+      const world = new World<Entity>()
+      const entity = world.add({ name: "John" })
+      expect(entity.name).toEqual("John")
+
+      world.update(entity, { name: "Jane" })
+      expect(entity.name).toEqual("Jane")
+    })
+
+    it("triggers a reindexing of the entity by any derived buckets", () => {
+      const world = new World<Entity>()
+      const entity = world.add({ name: "John" })
+      expect(entity.name).toEqual("John")
+
+      const hasAge = world.archetype("age")
+      expect(hasAge.entities).toEqual([])
+
+      world.update(entity, { age: 28 })
+      expect(hasAge.entities).toEqual([entity])
+    })
+  })
+
   describe("id", () => {
     it("returns undefined for entities not in the world", () => {
       const world = new World<Entity>()

--- a/packages/miniplex-core/test/World.test.ts
+++ b/packages/miniplex-core/test/World.test.ts
@@ -55,6 +55,12 @@ describe(World, () => {
       world.update(entity, { age: 28 })
       expect(hasAge.entities).toEqual([entity])
     })
+
+    it("returns the entity", () => {
+      const world = new World<Entity>()
+      const entity = world.add({ name: "John" })
+      expect(world.update(entity, { name: "Jane" })).toEqual(entity)
+    })
   })
 
   describe("id", () => {

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -22,7 +22,7 @@ type CommonProps<E> = {
   children?: EntityChildren<E>
 }
 
-export const createReactAPI = <E,>(world: World<E>) => {
+export const createReactAPI = <E extends {}>(world: World<E>) => {
   const EntityContext = createContext<E | null>(null)
 
   const useCurrentEntity = () => useContext(EntityContext)


### PR DESCRIPTION
Added an `update` function to the `World` class that allows the user to update an entity. This is intended to complement the other two mutating functions (`addComponent`, `removeComponent`), simply to allow for the use of syntactic sugar (component constructor functions, entity factories, etc.) in a streamlined fashion:

```js
/* With an object with changes */
world.update(entity, { age: entity.age + 1 })

/* With a function returning an object with changes */
const increaseAge = ({age}) => ({ age: age + 1 }
world.update(entity, increaseAge)

/* With a function that mutates the entity directly: */
const mutatingIncreaseAge = (entity) => entity.age++
world.update(entity, mutatingIncreaseAge)
```

The main job of the function is to re-index the updated entity against known derived buckets, and since in Miniplex you'll typically mutate entities directly, it can even be called with _only_ an entity. All of the above are essentially equivalent to:

```js
entity.age++
world.update(entity)
```
