### PR TITLE
Remove `<Archetype>` component

### DIFF
--- a/.changeset/sweet-kings-turn.md
+++ b/.changeset/sweet-kings-turn.md
@@ -6,8 +6,9 @@
 
 ```jsx
 /* Before: */
-<Archetype with={["enemy", "alive"]} />
+<Archetype with={["enemy", "attacking"]} without="dead" />
 
 /* After: */
-<Entities in={world.with("enemy", "alive")} />
+const attackingEnemies = world.with("enemy", "attacking").without("dead")
+<Entities in={attackingEnemies} />
 ```

--- a/.changeset/sweet-kings-turn.md
+++ b/.changeset/sweet-kings-turn.md
@@ -8,7 +8,10 @@
 /* Before: */
 <Archetype with={["enemy", "attacking"]} without="dead" />
 
-/* After: */
+/* After (inline): */
+<Entities in={world.with("enemy", "attacking").without("dead")} />
+
+/* After (out of band): */
 const attackingEnemies = world.with("enemy", "attacking").without("dead")
 <Entities in={attackingEnemies} />
 ```

--- a/.changeset/sweet-kings-turn.md
+++ b/.changeset/sweet-kings-turn.md
@@ -1,0 +1,13 @@
+---
+"@miniplex/react": patch
+---
+
+**Breaking Change:** Removed the `<Archetype>` component. Please use `<Entities in={...} />` instead:
+
+```jsx
+/* Before: */
+<Archetype with={["enemy", "alive"]} />
+
+/* After: */
+<Entities in={world.with("enemy", "alive")} />
+```

--- a/apps/demo/src/entities/Bullets.tsx
+++ b/apps/demo/src/entities/Bullets.tsx
@@ -7,16 +7,17 @@ import { physics } from "../systems/PhysicsSystem"
 import { bitmask } from "../util/bitmask"
 import { RenderableEntity } from "./RenderableEntity"
 
+const players = ECS.world.with("isPlayer")
+const bullets = ECS.world.with("isBullet")
+
 export const Bullets = () => (
   <InstancedParticles>
     <planeGeometry args={[0.15, 0.5]} />
     <meshStandardMaterial color={new Color("orange").multiplyScalar(5)} />
 
-    <ECS.Archetype with="isBullet" children={RenderableEntity} />
+    <ECS.Entities in={bullets} children={RenderableEntity} />
   </InstancedParticles>
 )
-
-const players = ECS.world.with("isPlayer")
 
 const jitter = new Quaternion()
 const axisZ = new Vector3(0, 0, 1)

--- a/packages/miniplex-react/src/createReactAPI.tsx
+++ b/packages/miniplex-react/src/createReactAPI.tsx
@@ -1,4 +1,4 @@
-import { Bucket, With, World } from "@miniplex/core"
+import { Bucket, World } from "@miniplex/core"
 import React, {
   createContext,
   memo,
@@ -7,7 +7,6 @@ import React, {
   useContext,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef
 } from "react"
 import { useEntities as useEntitiesGlobal } from "./hooks"
@@ -97,31 +96,6 @@ export const createReactAPI = <E extends {}>(world: World<E>) => {
     }
   }
 
-  function Archetype<P extends keyof E>({
-    with: _with,
-    without,
-    ...props
-  }: CommonProps<With<E, P>> & {
-    with?: P | P[]
-    without?: keyof E | (keyof E)[]
-  }) {
-    const query = useMemo(
-      () => ({
-        with: _with ? (Array.isArray(_with) ? _with : [_with]) : undefined,
-        without: without
-          ? Array.isArray(without)
-            ? without
-            : [without]
-          : undefined
-      }),
-      [_with, without]
-    )
-
-    const bucket = useMemo(() => world.archetype(query), [world, query])
-
-    return <EntitiesInBucket {...props} bucket={bucket} />
-  }
-
   const Component = <P extends keyof E>(props: {
     name: P
     data?: E[P]
@@ -162,7 +136,6 @@ export const createReactAPI = <E extends {}>(world: World<E>) => {
     world,
     Component,
     Entity,
-    Archetype,
     Entities,
     useCurrentEntity
   }

--- a/packages/miniplex-react/test/createReactAPI.test.tsx
+++ b/packages/miniplex-react/test/createReactAPI.test.tsx
@@ -268,64 +268,6 @@ describe("<Entities>", () => {
   })
 })
 
-describe("<Archetype>", () => {
-  it("renders the entities that match the archetype", () => {
-    const world = new World<Entity>()
-    const { Archetype } = createReactAPI(world)
-
-    world.add({ name: "John", age: 45 })
-    world.add({ name: "Alice" })
-    world.add({ name: "Charlie", age: 32, height: 180 })
-
-    render(
-      <Archetype with="age" without="height">
-        {(entity) => <p>{entity.name}</p>}
-      </Archetype>
-    )
-
-    expect(screen.getByText("John")).toBeInTheDocument()
-    expect(screen.queryByText("Alice")).toBeNull()
-    expect(screen.queryByText("Charlie")).toBeNull()
-  })
-
-  it("re-renders the entities when the archetype matches change", () => {
-    const world = new World<Entity>()
-    const { Archetype } = createReactAPI(world)
-
-    world.add({ name: "John", age: 45 })
-    const alice = world.add({ name: "Alice" })
-
-    render(<Archetype with="age">{(entity) => <p>{entity.name}</p>}</Archetype>)
-
-    expect(screen.getByText("John")).toBeInTheDocument()
-    expect(screen.queryByText("Alice")).toBeNull()
-
-    act(() => {
-      world.addComponent(alice, "age", 30)
-    })
-
-    expect(screen.getByText("Alice")).toBeInTheDocument()
-  })
-
-  describe("given a `children` prop", () => {
-    it("renders the entities using the given component, passing the entity to it", () => {
-      const world = new World<Entity>()
-      const { Archetype } = createReactAPI(world)
-
-      world.add({ name: "John", age: 45 })
-      world.add({ name: "Alice" })
-      world.add({ name: "Charlie", age: 32, height: 180 })
-
-      const User = ({ name }: { name: string }) => <div>{name}</div>
-
-      render(<Archetype with="age" children={User} />)
-
-      expect(screen.getByText("John")).toBeInTheDocument()
-      expect(screen.queryByText("Alice")).toBeNull()
-    })
-  })
-})
-
 describe("world", () => {
   it("is a reference to the world originally passed into createReactAPI", () => {
     const world = new World<{ name: string }>()


### PR DESCRIPTION
```jsx
/* Before: */
<Archetype with={["enemy", "attacking"]} without="dead" />

/* After (inline): */
<Entities in={world.with("enemy", "attacking").without("dead")} />

/* After (out of band): */
const attackingEnemies = world.with("enemy", "attacking").without("dead")
<Entities in={attackingEnemies} />
```

Reasoning: both allow the user to quickly render a list of entities identified by archetype, but the `<Entities in={} />` form was always the more "Miniplex 2.0 idiomatic" one (since it doesn't really care about how the passed archetype was constructed, and 2.0 introducing new ways to construct them.) It also encourages the user to construct their archetypes out of band, which is heavily recommended, while the `<Archetype>` component would always go through the memoization checks.