### PR TITLE
Update bucket events and add `onEnter`

### DIFF
--- a/packages/miniplex-bucket/src/Bucket.ts
+++ b/packages/miniplex-bucket/src/Bucket.ts
@@ -48,12 +48,12 @@ export class Bucket<E> implements Iterable<E> {
   /**
    * Fired when an entity has been added to the bucket.
    */
-  onEntityAdded = new Event<[entity: E]>()
+  onAdd = new Event<[entity: E]>()
 
   /**
    * Fired when an entity is about to be removed from the bucket.
    */
-  onEntityRemoved = new Event<[entity: E]>()
+  onRemove = new Event<[entity: E]>()
 
   /**
    * Fired when an entity enters this bucket. The main difference between this and
@@ -104,7 +104,7 @@ export class Bucket<E> implements Iterable<E> {
       this.entityPositions.set(entity, this.entities.length - 1)
 
       /* Emit relevant events */
-      this.onEntityAdded.emit(entity)
+      this.onAdd.emit(entity)
       this.onEnter.emit(entity)
     }
 
@@ -122,7 +122,7 @@ export class Bucket<E> implements Iterable<E> {
     /* TODO: Return early if entity is not in bucket. */
     if (this.has(entity)) {
       /* Emit our own onEntityRemoved event. */
-      this.onEntityRemoved.emit(entity)
+      this.onRemove.emit(entity)
 
       /* Get the entity's current position. */
       const index = this.entityPositions.get(entity)!

--- a/packages/miniplex-bucket/src/Bucket.ts
+++ b/packages/miniplex-bucket/src/Bucket.ts
@@ -36,6 +36,13 @@ export class Bucket<E> implements Iterable<E> {
     for (let i = 0; i < _entities.length; i++) {
       this.entityPositions.set(_entities[i], i)
     }
+
+    /* React to listeners being added to onEnter */
+    this.onEnter.onSubscribe.subscribe((listener) => {
+      for (const entity of this) {
+        listener(entity)
+      }
+    })
   }
 
   /**
@@ -47,6 +54,13 @@ export class Bucket<E> implements Iterable<E> {
    * Fired when an entity is about to be removed from the bucket.
    */
   onEntityRemoved = new Event<[entity: E]>()
+
+  /**
+   * Fired when an entity enters this bucket. The main difference between this and
+   * `onAdd` is that when new listeners are added to this event, they will also
+   * be applied to all entities that are already in the bucket.
+   */
+  onEnter = new Event<[entity: E]>()
 
   /**
    * A map of entity positions, used for fast lookups.
@@ -89,8 +103,9 @@ export class Bucket<E> implements Iterable<E> {
       this.entities.push(entity)
       this.entityPositions.set(entity, this.entities.length - 1)
 
-      /* Emit our own onEntityAdded event */
+      /* Emit relevant events */
       this.onEntityAdded.emit(entity)
+      this.onEnter.emit(entity)
     }
 
     return entity

--- a/packages/miniplex-bucket/test/Bucket.test.ts
+++ b/packages/miniplex-bucket/test/Bucket.test.ts
@@ -40,12 +40,12 @@ describe(Bucket, () => {
       expect(bucket.entities).toHaveLength(0)
     })
 
-    it("emits the onEntityAdded event", () => {
+    it("emits the onAdd event", () => {
       const bucket = new Bucket()
       const entity = { id: "1" }
       const listener = jest.fn()
 
-      bucket.onEntityAdded.subscribe(listener)
+      bucket.onAdd.subscribe(listener)
       bucket.add(entity)
 
       expect(listener).toHaveBeenCalledWith(entity)
@@ -72,12 +72,12 @@ describe(Bucket, () => {
       expect(result).toBe(entity)
     })
 
-    it("emits the onEntityRemoved event", () => {
+    it("emits the onRemove event", () => {
       const bucket = new Bucket()
       const entity = bucket.add({ id: "1" })
       const listener = jest.fn()
 
-      bucket.onEntityRemoved.subscribe(listener)
+      bucket.onRemove.subscribe(listener)
       bucket.remove(entity)
 
       expect(listener).toHaveBeenCalledWith(entity)
@@ -122,7 +122,7 @@ describe(Bucket, () => {
       const entity2 = bucket.add({ id: "2" })
       const listener = jest.fn()
 
-      bucket.onEntityRemoved.subscribe(listener)
+      bucket.onRemove.subscribe(listener)
       bucket.clear()
 
       expect(listener).toHaveBeenCalledWith(entity1)
@@ -149,6 +149,41 @@ describe(Bucket, () => {
       bucket.onEnter.subscribe(listener)
 
       expect(listener).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe("onAdd event", () => {
+    it("is emitted when an entity is added to the bucket", () => {
+      const bucket = new Bucket()
+      const entity = { id: "1" }
+      const listener = jest.fn()
+
+      bucket.onAdd.subscribe(listener)
+      bucket.add(entity)
+
+      expect(listener).toHaveBeenCalledWith(entity)
+    })
+
+    it("is not applied to entities already in the bucket", () => {
+      const bucket = new Bucket([1, 2, 3])
+      const listener = jest.fn()
+
+      bucket.onAdd.subscribe(listener)
+
+      expect(listener).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe("onRemove event", () => {
+    it("is emitted when an entity is removed from the bucket", () => {
+      const bucket = new Bucket()
+      const entity = bucket.add({ id: "1" })
+      const listener = jest.fn()
+
+      bucket.onRemove.subscribe(listener)
+      bucket.remove(entity)
+
+      expect(listener).toHaveBeenCalledWith(entity)
     })
   })
 })

--- a/packages/miniplex-bucket/test/Bucket.test.ts
+++ b/packages/miniplex-bucket/test/Bucket.test.ts
@@ -129,4 +129,26 @@ describe(Bucket, () => {
       expect(listener).toHaveBeenCalledWith(entity2)
     })
   })
+
+  describe("onEnter event", () => {
+    it("is emitted when an entity is added to the bucket", () => {
+      const bucket = new Bucket()
+      const entity = { id: "1" }
+      const listener = jest.fn()
+
+      bucket.onEnter.subscribe(listener)
+      bucket.add(entity)
+
+      expect(listener).toHaveBeenCalledWith(entity)
+    })
+
+    it("automatically applies to entities that are already in the bucket", () => {
+      const bucket = new Bucket([1, 2, 3])
+      const listener = jest.fn()
+
+      bucket.onEnter.subscribe(listener)
+
+      expect(listener).toHaveBeenCalledTimes(3)
+    })
+  })
 })

--- a/packages/miniplex-core/src/core.ts
+++ b/packages/miniplex-core/src/core.ts
@@ -68,13 +68,13 @@ export class World<E extends {} = any>
     super(entities)
 
     /* When entities are added, reindex them immediately */
-    this.onEntityAdded.subscribe((entity) => {
+    this.onAdd.subscribe((entity) => {
       this.reindex(entity)
     })
 
     /* When entities are removed, remove them from all known queries, and delete
     their IDs */
-    this.onEntityRemoved.subscribe((entity) => {
+    this.onRemove.subscribe((entity) => {
       this.queries.forEach((query) => query.remove(entity))
 
       if (this.entityToId.has(entity)) {
@@ -245,8 +245,8 @@ export class Query<E> extends Bucket<E> implements IQueryableBucket<E> {
 
     /* Automatically connect this query if event listeners are added to our
     onEntityAdded or onEntityRemoved events. */
-    this.onEntityAdded.onSubscribe.subscribe(() => this.connect())
-    this.onEntityRemoved.onSubscribe.subscribe(() => this.connect())
+    this.onAdd.onSubscribe.subscribe(() => this.connect())
+    this.onRemove.onSubscribe.subscribe(() => this.connect())
   }
 
   get entities() {

--- a/packages/miniplex-core/test/core.test.ts
+++ b/packages/miniplex-core/test/core.test.ts
@@ -266,7 +266,7 @@ describe(World, () => {
       const withAge = world.with("age")
       expect(withAge.isConnected).toBe(false)
 
-      withAge.onEntityAdded.subscribe(() => {})
+      withAge.onAdd.subscribe(() => {})
       expect(withAge.isConnected).toBe(true)
     })
 
@@ -275,7 +275,7 @@ describe(World, () => {
       const withAge = world.with("age")
       expect(withAge.isConnected).toBe(false)
 
-      withAge.onEntityRemoved.subscribe(() => {})
+      withAge.onRemove.subscribe(() => {})
       expect(withAge.isConnected).toBe(true)
     })
   })
@@ -369,7 +369,7 @@ describe(World, () => {
       const entity = world.add({ name: "John", age: 30 })
       expect(query.entities).toEqual([entity])
 
-      query.onEntityRemoved.subscribe((removedEntity) => {
+      query.onRemove.subscribe((removedEntity) => {
         expect(removedEntity).toEqual(entity)
         expect(removedEntity.age).toEqual(30)
       })

--- a/packages/miniplex-react/src/hooks.ts
+++ b/packages/miniplex-react/src/hooks.ts
@@ -17,7 +17,7 @@ export function useOnEntityAdded<E>(
   callback: (entity: E) => void
 ) {
   useIsomorphicLayoutEffect(
-    () => bucket.onEntityAdded.subscribe(callback),
+    () => bucket.onAdd.subscribe(callback),
     [bucket, callback]
   )
 }
@@ -27,7 +27,7 @@ export function useOnEntityRemoved<E>(
   callback: (entity: E) => void
 ) {
   useIsomorphicLayoutEffect(
-    () => bucket.onEntityRemoved.subscribe(callback),
+    () => bucket.onRemove.subscribe(callback),
     [bucket, callback]
   )
 }


### PR DESCRIPTION
As an alternative to Monitors.

### TODO

- [ ] Update React hooks (`onEntityAdded` vs. `onAdd` is a bit iffy... eh)
- [ ] Fix demos
- [ ] Documentation
- [ ] Changeset