### PR TITLE
Fix disappearing asteroids and bullets

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@hmans/r3f-animate": "^0.0.5",
     "@hmans/use-const": "^0.0.1",
-    "@react-three/drei": "^9.66.6",
-    "@react-three/fiber": "^8.13.0",
+    "@react-three/drei": "^9.78.1",
+    "@react-three/fiber": "^8.13.4",
     "add": "^2.0.6",
     "material-composer": "^0.2.6",
     "material-composer-r3f": "^0.2.5",
@@ -25,7 +25,7 @@
     "render-composer": "^0.2.8",
     "shader-composer": "^0.4.9",
     "shader-composer-toybox": "^0.1.3",
-    "three": "^0.152.2",
+    "three": "^0.154.0",
     "three-stdlib": "^2.21.11",
     "vfx-composer": "^0.4.0",
     "vfx-composer-r3f": "^0.4.0"

--- a/apps/demo/src/entities/Asteroids.tsx
+++ b/apps/demo/src/entities/Asteroids.tsx
@@ -37,7 +37,7 @@ export const Asteroids = () => {
   const rand = InstanceRNG()
 
   return (
-    <InstancedParticles capacity={20000}>
+    <InstancedParticles capacity={20000} frustumCulled={false}>
       <icosahedronGeometry />
 
       <Composable.MeshStandardMaterial metalness={0.1} roughness={0.8}>

--- a/apps/demo/src/entities/Bullets.tsx
+++ b/apps/demo/src/entities/Bullets.tsx
@@ -11,7 +11,7 @@ const players = ECS.world.with("isPlayer")
 const bullets = ECS.world.with("isBullet")
 
 export const Bullets = () => (
-  <InstancedParticles>
+  <InstancedParticles frustumCulled={false}>
     <planeGeometry args={[0.15, 0.5]} />
     <meshStandardMaterial color={new Color("orange").multiplyScalar(5)} />
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -72,34 +76,34 @@ importers:
     dependencies:
       '@hmans/r3f-animate':
         specifier: ^0.0.5
-        version: 0.0.5(@react-three/fiber@8.13.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+        version: 0.0.5(@react-three/fiber@8.13.4)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       '@hmans/use-const':
         specifier: ^0.0.1
         version: 0.0.1(react@18.2.0)
       '@react-three/drei':
-        specifier: ^9.66.6
-        version: 9.66.6(@react-three/fiber@8.13.0)(@types/three@0.152.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+        specifier: ^9.78.1
+        version: 9.78.1(@react-three/fiber@8.13.4)(@types/three@0.152.0)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       '@react-three/fiber':
-        specifier: ^8.13.0
-        version: 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+        specifier: ^8.13.4
+        version: 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       add:
         specifier: ^2.0.6
         version: 2.0.6
       material-composer:
         specifier: ^0.2.6
-        version: 0.2.6(three@0.152.2)
+        version: 0.2.6(three@0.154.0)
       material-composer-r3f:
         specifier: ^0.2.5
-        version: 0.2.5(@react-three/fiber@8.13.0)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+        version: 0.2.5(@react-three/fiber@8.13.4)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       miniplex:
         specifier: workspace:2.0.0-beta.3
         version: link:../../packages/miniplex
       postprocessing:
         specifier: ^6.31.0
-        version: 6.31.0(three@0.152.2)
+        version: 6.31.0(three@0.154.0)
       r3f-perf:
         specifier: ^6.7.0
-        version: 6.7.0(@react-three/drei@9.66.6)(@react-three/fiber@8.13.0)(react-dom@18.2.0)(react@18.2.0)(three-stdlib@2.21.11)(three@0.152.2)
+        version: 6.7.0(@react-three/drei@9.78.1)(@react-three/fiber@8.13.4)(react-dom@18.2.0)(react@18.2.0)(three-stdlib@2.21.11)(three@0.154.0)
       randomish:
         specifier: ^0.1.6
         version: 0.1.6
@@ -111,25 +115,25 @@ importers:
         version: 18.2.0(react@18.2.0)
       render-composer:
         specifier: ^0.2.8
-        version: 0.2.8(@react-three/fiber@8.13.0)(postprocessing@6.31.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+        version: 0.2.8(@react-three/fiber@8.13.4)(postprocessing@6.31.0)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       shader-composer:
         specifier: ^0.4.9
-        version: 0.4.9(three@0.152.2)
+        version: 0.4.9(three@0.154.0)
       shader-composer-toybox:
         specifier: ^0.1.3
-        version: 0.1.3(three@0.152.2)
+        version: 0.1.3(three@0.154.0)
       three:
-        specifier: ^0.152.2
-        version: 0.152.2
+        specifier: ^0.154.0
+        version: 0.154.0
       three-stdlib:
         specifier: ^2.21.11
-        version: 2.21.11(three@0.152.2)
+        version: 2.21.11(three@0.154.0)
       vfx-composer:
         specifier: ^0.4.0
-        version: 0.4.0(three@0.152.2)
+        version: 0.4.0(three@0.154.0)
       vfx-composer-r3f:
         specifier: ^0.4.0
-        version: 0.4.0(@react-three/fiber@8.13.0)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+        version: 0.4.0(@react-three/fiber@8.13.4)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
     devDependencies:
       '@types/react':
         specifier: ^18.2.6
@@ -2088,7 +2092,7 @@ packages:
     resolution: {integrity: sha512-Mm8oQRFRoiEYQ3QD9CD14DTaShd21nzNrUFyBhFxy+TduKf2PdMRfHHx7lDvEpbODGNlj+e8mcWGj/YjWmC3Bw==}
     dev: false
 
-  /@hmans/r3f-animate@0.0.5(@react-three/fiber@8.13.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2):
+  /@hmans/r3f-animate@0.0.5(@react-three/fiber@8.13.4)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0):
     resolution: {integrity: sha512-xxQLRr1qRdI0oNNMbW2KCH82uLrPu8l5ktC5hEToKJ5QlBk6ttVDB0bvRT7BCWWoCi9KVPvNdTTNmnT+VwWRhA==}
     peerDependencies:
       '@react-three/fiber': '>=8.0.27'
@@ -2096,23 +2100,23 @@ packages:
       react-dom: '>=18.1.0'
       three: '>=0.141.0'
     dependencies:
-      '@hmans/r3f-lifecycle': 0.0.4(@react-three/fiber@8.13.0)(react@18.2.0)(three@0.152.2)
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+      '@hmans/r3f-lifecycle': 0.0.4(@react-three/fiber@8.13.4)(react@18.2.0)(three@0.154.0)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
-  /@hmans/r3f-lifecycle@0.0.4(@react-three/fiber@8.13.0)(react@18.2.0)(three@0.152.2):
+  /@hmans/r3f-lifecycle@0.0.4(@react-three/fiber@8.13.4)(react@18.2.0)(three@0.154.0):
     resolution: {integrity: sha512-q019sVRtjBrEVJeZaP2Jc0AG/yXae5B06xSHVZ8I2l1ujC7Cv7apbG2cM7hZig8EfObHR+lkkxz293PdgWJnlw==}
     peerDependencies:
       '@react-three/fiber': '>=8.0.27'
       react: '>=18.1.0'
       three: '>=0.141.0'
     dependencies:
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       react: 18.2.0
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
   /@hmans/signal@0.2.2:
@@ -2489,7 +2493,7 @@ packages:
       read-yaml-file: 1.1.0
     dev: false
 
-  /@material-composer/patch-material@0.1.3(shader-composer@0.4.9)(three@0.152.2):
+  /@material-composer/patch-material@0.1.3(shader-composer@0.4.9)(three@0.154.0):
     resolution: {integrity: sha512-ZBWJTwfDk2OqO9sduBiV7DaIc2oL2D8Z9KtaZ/Y3ObNEQvwO8V6EVyzeBYlzbyJMOoyy+hR9g9TG/efM35TNzA==}
     peerDependencies:
       shader-composer: '>=0.3.4'
@@ -2497,11 +2501,11 @@ packages:
     dependencies:
       '@hmans/types': 0.0.3
       fp-ts: 2.15.0
-      shader-composer: 0.4.9(three@0.152.2)
-      three: 0.152.2
+      shader-composer: 0.4.9(three@0.154.0)
+      three: 0.154.0
     dev: false
 
-  /@material-composer/patched@0.1.3(@react-three/fiber@8.13.0)(react@18.2.0)(shader-composer@0.4.9)(three@0.152.2):
+  /@material-composer/patched@0.1.3(@react-three/fiber@8.13.4)(react@18.2.0)(shader-composer@0.4.9)(three@0.154.0):
     resolution: {integrity: sha512-61jgdFgHT7GA7y302xFSZ3oiR3YDoYclsp9HJx9581aVXOfyEaNVpMVuOLToyJQO/irEjUigSCNKUrmgsztLmg==}
     peerDependencies:
       '@react-three/fiber': ^8.6.0
@@ -2509,14 +2513,18 @@ packages:
       three: '>=0.141.0'
     dependencies:
       '@hmans/types': 0.0.3
-      '@material-composer/patch-material': 0.1.3(shader-composer@0.4.9)(three@0.152.2)
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+      '@material-composer/patch-material': 0.1.3(shader-composer@0.4.9)(three@0.154.0)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       fp-ts: 2.15.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      three: 0.152.2
+      three: 0.154.0
     transitivePeerDependencies:
       - shader-composer
+    dev: false
+
+  /@mediapipe/tasks-vision@0.10.2-rc2:
+    resolution: {integrity: sha512-b9ar6TEUo8I07n/jXSuKDu5HgzkDah9pe4H8BYpcubhCEahlfDD5ixE+9SQyJM4HXHXdF9nN/wRQT7rEnLz7Gg==}
     dev: false
 
   /@nodelib/fs.scandir@2.1.5:
@@ -2640,7 +2648,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@react-spring/three@9.6.1(@react-three/fiber@8.13.0)(react@18.2.0)(three@0.152.2):
+  /@react-spring/three@9.6.1(@react-three/fiber@8.13.4)(react@18.2.0)(three@0.154.0):
     resolution: {integrity: sha512-Tyw2YhZPKJAX3t2FcqvpLRb71CyTe1GvT3V+i+xJzfALgpk10uPGdGaQQ5Xrzmok1340DAeg2pR/MCfaW7b8AA==}
     peerDependencies:
       '@react-three/fiber': '>=6.0'
@@ -2651,17 +2659,17 @@ packages:
       '@react-spring/core': 9.6.1(react@18.2.0)
       '@react-spring/shared': 9.6.1(react@18.2.0)
       '@react-spring/types': 9.6.1
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       react: 18.2.0
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
   /@react-spring/types@9.6.1:
     resolution: {integrity: sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q==}
     dev: false
 
-  /@react-three/drei@9.66.6(@react-three/fiber@8.13.0)(@types/three@0.152.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2):
-    resolution: {integrity: sha512-AQzuzawov5375PT612a4G1bNHLf31QxcZmfVSCFt9p4PolBgHtvkQGA8IDiCJRkbYYrOH4tOymfQEU6+f5Nmuw==}
+  /@react-three/drei@9.78.1(@react-three/fiber@8.13.4)(@types/three@0.152.0)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0):
+    resolution: {integrity: sha512-Q7BYEt5G5pLxdNbI14Zv/nfxEAS8sYuQvIa+xDvspMQB1x6/+ULZavLoOQ5OtpJ4+n/yxoIk3XZ5l3j0gvB0cg==}
     peerDependencies:
       '@react-three/fiber': '>=8.0'
       react: '>=18.0'
@@ -2671,36 +2679,37 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.19.0
-      '@react-spring/three': 9.6.1(@react-three/fiber@8.13.0)(react@18.2.0)(three@0.152.2)
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+      '@babel/runtime': 7.21.5
+      '@mediapipe/tasks-vision': 0.10.2-rc2
+      '@react-spring/three': 9.6.1(@react-three/fiber@8.13.4)(react@18.2.0)(three@0.154.0)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       '@use-gesture/react': 10.2.26(react@18.2.0)
-      camera-controls: 2.3.4(three@0.152.2)
-      detect-gpu: 5.0.23
+      camera-controls: 2.7.0(three@0.154.0)
+      detect-gpu: 5.0.31
       glsl-noise: 0.0.0
       lodash.clamp: 4.0.3
       lodash.omit: 4.5.0
       lodash.pick: 4.4.0
-      maath: 0.5.3(@types/three@0.152.0)(three@0.152.2)
-      meshline: 3.1.6(three@0.152.2)
+      maath: 0.6.0(@types/three@0.152.0)(three@0.154.0)
+      meshline: 3.1.6(three@0.154.0)
       react: 18.2.0
       react-composer: 5.0.3(react@18.2.0)
       react-dom: 18.2.0(react@18.2.0)
       react-merge-refs: 1.1.0
       stats.js: 0.17.0
-      suspend-react: 0.0.8(react@18.2.0)
-      three: 0.152.2
-      three-mesh-bvh: 0.5.23(three@0.152.2)
-      three-stdlib: 2.21.11(three@0.152.2)
-      troika-three-text: 0.47.1(three@0.152.2)
+      suspend-react: 0.1.3(react@18.2.0)
+      three: 0.154.0
+      three-mesh-bvh: 0.6.1(three@0.154.0)
+      three-stdlib: 2.23.13(three@0.154.0)
+      troika-three-text: 0.47.2(three@0.154.0)
       utility-types: 3.10.0
       zustand: 3.7.2(react@18.2.0)
     transitivePeerDependencies:
       - '@types/three'
     dev: false
 
-  /@react-three/fiber@8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2):
-    resolution: {integrity: sha512-hPFzFNgikEMyEbL+NpSA7q+UWZxInrrkJldWaCR2w34Fwf20x9p68bsyN0/yn9oM2VlWoJcJjR8hw1tN9AxHuA==}
+  /@react-three/fiber@8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0):
+    resolution: {integrity: sha512-OmyRKt9JU2i/Rc3uw4A+zERXKkFdu8slJjWQZfacoFNHIzGP9QVQ9XxlJWgTbgTLIOD39cUgnmH3RZZGWJqAoQ==}
     peerDependencies:
       expo: '>=43.0'
       expo-asset: '>=8.4'
@@ -2721,7 +2730,7 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@babel/runtime': 7.19.0
+      '@babel/runtime': 7.21.5
       '@types/react-reconciler': 0.26.7
       its-fine: 1.0.6(react@18.2.0)
       react: 18.2.0
@@ -2729,8 +2738,8 @@ packages:
       react-reconciler: 0.27.0(react@18.2.0)
       react-use-measure: 2.1.1(react-dom@18.2.0)(react@18.2.0)
       scheduler: 0.21.0
-      suspend-react: 0.0.8(react@18.2.0)
-      three: 0.152.2
+      suspend-react: 0.1.3(react@18.2.0)
+      three: 0.154.0
       zustand: 3.7.2(react@18.2.0)
     dev: false
 
@@ -2934,6 +2943,10 @@ packages:
       '@babel/types': 7.21.5
     dev: false
 
+  /@types/draco3d@1.4.2:
+    resolution: {integrity: sha512-goh23EGr6CLV6aKPwN1p8kBD/7tT5V/bLpToSbarKrwVejqNrspVrv8DhliteYkkhZYrlq/fwKZRRUzH4XN88w==}
+    dev: false
+
   /@types/estree@0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: false
@@ -3076,6 +3089,10 @@ packages:
 
   /@types/webxr@0.5.1:
     resolution: {integrity: sha512-xlFXPfgJR5vIuDefhaHuUM9uUgvPaXB6GKdXy2gdEh8gBWQZ2ul24AJz3foUd8NNKlSTQuWYJpCb1/pL81m1KQ==}
+
+  /@types/webxr@0.5.2:
+    resolution: {integrity: sha512-szL74BnIcok9m7QwYtVmQ+EdIKwbjPANudfuvDrAF8Cljg9MKUlIoc1w5tjj9PMpeSH3U1Xnx//czQybJ0EfSw==}
+    dev: false
 
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -3493,12 +3510,12 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /camera-controls@2.3.4(three@0.152.2):
-    resolution: {integrity: sha512-swhc87YVHf9te0glBI7Oa/QBgsSCL4ZxtoR4V3vE6l7mEebsYRNL8y7Y2m2E6MrT0UTphM1S7mQqs0Sp7QTZ2g==}
+  /camera-controls@2.7.0(three@0.154.0):
+    resolution: {integrity: sha512-HONMoMYHieOCQOoweS639bdWHP/P/fvVGR08imnECGVUp04mqGfsX/zp1ZufLeiAA5hA6i1JhP6SrnOwh01C0w==}
     peerDependencies:
       three: '>=0.126.1'
     dependencies:
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
   /caniuse-lite@1.0.30001486:
@@ -3835,8 +3852,8 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: false
 
-  /detect-gpu@5.0.23:
-    resolution: {integrity: sha512-16bbvNSuGxlznAj7XNW8/7M/EtPuWoSGk1X1EJCipQ/F5JQK6tWMdU2xVInXGTRUMKmsDtZg+trnZ/bj0Vt/EA==}
+  /detect-gpu@5.0.31:
+    resolution: {integrity: sha512-+ZZr/deA5OvuBxod6kKFUvpZA9YR2r4fRYlAJGL7N5aUSLrY3Xgi+K4U5NHmeuk2mNC044n1YJwsq2Aw6hPmUw==}
     dependencies:
       webgl-constants: 1.1.1
     dev: false
@@ -5399,7 +5416,7 @@ packages:
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: false
 
   /jsonfile@6.1.0:
@@ -5407,7 +5424,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: false
 
   /kind-of@6.0.3:
@@ -5453,7 +5470,7 @@ packages:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
@@ -5535,14 +5552,14 @@ packages:
     hasBin: true
     dev: false
 
-  /maath@0.5.3(@types/three@0.152.0)(three@0.152.2):
-    resolution: {integrity: sha512-ut63A4zTd9abtpi+sOHW1fPWPtAFrjK0E17eAthx1k93W/T2cWLKV5oaswyotJVDvvW1EXSdokAqhK5KOu0Qdw==}
+  /maath@0.6.0(@types/three@0.152.0)(three@0.154.0):
+    resolution: {integrity: sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==}
     peerDependencies:
       '@types/three': '>=0.144.0'
       three: '>=0.144.0'
     dependencies:
       '@types/three': 0.152.0
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
   /magic-string@0.25.9:
@@ -5590,7 +5607,7 @@ packages:
     hasBin: true
     dev: false
 
-  /material-composer-r3f@0.2.5(@react-three/fiber@8.13.0)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2):
+  /material-composer-r3f@0.2.5(@react-three/fiber@8.13.4)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0):
     resolution: {integrity: sha512-sdbfLEHfNRenySsBZlmETWJTqNfSgaaoDepJmdMrEhYUPz4n6CWE+IffxNiX2d7i3gn8P42AeHTXQGrlDFvsWg==}
     peerDependencies:
       '@react-three/fiber': '>=8.0.27'
@@ -5604,27 +5621,27 @@ packages:
       '@hmans/use-mutable-list': 0.0.2(react@18.2.0)
       '@hmans/use-rerender': 0.0.2(react@18.2.0)
       '@hmans/use-version': 0.0.2(react@18.2.0)
-      '@material-composer/patch-material': 0.1.3(shader-composer@0.4.9)(three@0.152.2)
-      '@material-composer/patched': 0.1.3(@react-three/fiber@8.13.0)(react@18.2.0)(shader-composer@0.4.9)(three@0.152.2)
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
-      material-composer: 0.2.6(three@0.152.2)
+      '@material-composer/patch-material': 0.1.3(shader-composer@0.4.9)(three@0.154.0)
+      '@material-composer/patched': 0.1.3(@react-three/fiber@8.13.4)(react@18.2.0)(shader-composer@0.4.9)(three@0.154.0)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
+      material-composer: 0.2.6(three@0.154.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      shader-composer: 0.4.9(three@0.152.2)
-      shader-composer-r3f: 0.4.5(@react-three/fiber@8.13.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
-      three: 0.152.2
+      shader-composer: 0.4.9(three@0.154.0)
+      shader-composer-r3f: 0.4.5(@react-three/fiber@8.13.4)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
+      three: 0.154.0
     dev: false
 
-  /material-composer@0.2.6(three@0.152.2):
+  /material-composer@0.2.6(three@0.154.0):
     resolution: {integrity: sha512-EYWoSkuXYqeIUxHNjmUgJjiVaWN858/1141ULfJNmr/mS+ZHdahyGlC6fBhysnR3/YNZj5mb3ulT2/ALp+uoVw==}
     peerDependencies:
       three: '>=0.141.0'
     dependencies:
-      '@material-composer/patch-material': 0.1.3(shader-composer@0.4.9)(three@0.152.2)
+      '@material-composer/patch-material': 0.1.3(shader-composer@0.4.9)(three@0.154.0)
       fp-ts: 2.15.0
-      shader-composer: 0.4.9(three@0.152.2)
-      shader-composer-toybox: 0.1.3(three@0.152.2)
-      three: 0.152.2
+      shader-composer: 0.4.9(three@0.154.0)
+      shader-composer-toybox: 0.1.3(three@0.154.0)
+      three: 0.154.0
     dev: false
 
   /meow@6.1.1:
@@ -5670,12 +5687,12 @@ packages:
     engines: {node: '>= 8'}
     dev: false
 
-  /meshline@3.1.6(three@0.152.2):
+  /meshline@3.1.6(three@0.154.0):
     resolution: {integrity: sha512-8JZJOdaL5oz3PI/upG8JvP/5FfzYUOhrkJ8np/WKvXzl0/PZ2V9pqTvCIjSKv+w9ccg2xb+yyBhXAwt6ier3ug==}
     peerDependencies:
       three: '>=0.137'
     dependencies:
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
   /micromatch@4.0.5:
@@ -6023,13 +6040,13 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /postprocessing@6.31.0(three@0.152.2):
+  /postprocessing@6.31.0(three@0.154.0):
     resolution: {integrity: sha512-h1g2KDVrTS6QB4AHP55opp8FYzq66jJHh4JIFCptaj283RUX1y/tPkv8FBB2oK4WYrdPgqvElnKrXZwgiLWeHQ==}
     engines: {node: '>= 0.13.2'}
     peerDependencies:
       three: '>= 0.138.0 < 0.153.0'
     dependencies:
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
   /potpack@1.0.2:
@@ -6135,7 +6152,7 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /r3f-perf@6.7.0(@react-three/drei@9.66.6)(@react-three/fiber@8.13.0)(react-dom@18.2.0)(react@18.2.0)(three-stdlib@2.21.11)(three@0.152.2):
+  /r3f-perf@6.7.0(@react-three/drei@9.78.1)(@react-three/fiber@8.13.4)(react-dom@18.2.0)(react@18.2.0)(three-stdlib@2.21.11)(three@0.154.0):
     resolution: {integrity: sha512-VUpWsA+semjFbVt1G7KiIuq0X+di23v7E0YYQG5E/vK8A7x+1EaBhmW0J4SRmKorxUk1RZWNLrQ0hr1UpObXTA==}
     peerDependencies:
       '@react-three/drei': '*'
@@ -6146,13 +6163,13 @@ packages:
       three-stdlib: '*'
     dependencies:
       '@radix-ui/react-icons': 1.1.1(react@18.2.0)
-      '@react-three/drei': 9.66.6(@react-three/fiber@8.13.0)(@types/three@0.152.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+      '@react-three/drei': 9.78.1(@react-three/fiber@8.13.4)(@types/three@0.152.0)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       '@stitches/react': 1.2.8(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      three: 0.152.2
-      three-stdlib: 2.21.11(three@0.152.2)
+      three: 0.154.0
+      three-stdlib: 2.21.11(three@0.154.0)
       zustand: 4.3.8(react@18.2.0)
     transitivePeerDependencies:
       - immer
@@ -6352,7 +6369,7 @@ packages:
       jsesc: 0.5.0
     dev: false
 
-  /render-composer@0.2.8(@react-three/fiber@8.13.0)(postprocessing@6.31.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2):
+  /render-composer@0.2.8(@react-three/fiber@8.13.4)(postprocessing@6.31.0)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0):
     resolution: {integrity: sha512-MPGIVBjFdobIlVhz5+N6wYMDZF2Z1S0eS58WrhCM7pzCykzsO3rwMCr5l8MOxBygwM46RS5zLj4913VysB+oZQ==}
     peerDependencies:
       '@react-three/fiber': '>=8.5.0'
@@ -6364,15 +6381,15 @@ packages:
       '@hmans/use-const': 0.0.1(react@18.2.0)
       '@hmans/use-mutable-list': 0.0.2(react@18.2.0)
       '@hmans/use-nullable-state': 0.0.1(react@18.2.0)
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       fp-ts: 2.15.0
-      postprocessing: 6.31.0(three@0.152.2)
+      postprocessing: 6.31.0(three@0.154.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      shader-composer: 0.4.9(three@0.152.2)
-      shader-composer-postprocessing: 0.0.1(postprocessing@6.31.0)(shader-composer@0.4.9)(three@0.152.2)
+      shader-composer: 0.4.9(three@0.154.0)
+      shader-composer-postprocessing: 0.0.1(postprocessing@6.31.0)(shader-composer@0.4.9)(three@0.154.0)
       test: 3.2.1
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
   /require-directory@2.1.1:
@@ -6521,19 +6538,19 @@ packages:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: false
 
-  /shader-composer-postprocessing@0.0.1(postprocessing@6.31.0)(shader-composer@0.4.9)(three@0.152.2):
+  /shader-composer-postprocessing@0.0.1(postprocessing@6.31.0)(shader-composer@0.4.9)(three@0.154.0):
     resolution: {integrity: sha512-GjyqIoKUmQgLk+vvBjLx72mAjtC1D3/RpBp4Am6EHZ7TwGQ3JZH/o+oHHQtkzbJhtrHMS/cLDPVeAk6rgA3CCg==}
     peerDependencies:
       postprocessing: ^6.28.7
       shader-composer: ^0.4.3
       three: '>=0.141.0'
     dependencies:
-      postprocessing: 6.31.0(three@0.152.2)
-      shader-composer: 0.4.9(three@0.152.2)
-      three: 0.152.2
+      postprocessing: 6.31.0(three@0.154.0)
+      shader-composer: 0.4.9(three@0.154.0)
+      three: 0.154.0
     dev: false
 
-  /shader-composer-r3f@0.4.5(@react-three/fiber@8.13.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2):
+  /shader-composer-r3f@0.4.5(@react-three/fiber@8.13.4)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0):
     resolution: {integrity: sha512-Ivgu0pyDKnNOUO9ndxkipkHcep5q4Tsyrlu4HcZS7fJDFIc55hAkIQjys5pM2XQhyiq87hG0gOQ52NjyiV3Jug==}
     peerDependencies:
       '@react-three/fiber': ^8.2.0
@@ -6542,31 +6559,31 @@ packages:
       three: '>=0.143.0'
     dependencies:
       '@hmans/use-const': 0.0.1(react@18.2.0)
-      '@material-composer/patch-material': 0.1.3(shader-composer@0.4.9)(three@0.152.2)
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+      '@material-composer/patch-material': 0.1.3(shader-composer@0.4.9)(three@0.154.0)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      shader-composer: 0.4.9(three@0.152.2)
-      three: 0.152.2
+      shader-composer: 0.4.9(three@0.154.0)
+      three: 0.154.0
     dev: false
 
-  /shader-composer-toybox@0.1.3(three@0.152.2):
+  /shader-composer-toybox@0.1.3(three@0.154.0):
     resolution: {integrity: sha512-5/aO+wjx4C1MOi91ckEi5sNOlqLtgvpnuzfmcEV8C3DVv7TQEGhkyUzmSUoS3G6WdEA8C2ybF9LkaYbgIs6aKg==}
     peerDependencies:
       three: '>=0.141.0'
     dependencies:
       fp-ts: 2.15.0
-      shader-composer: 0.4.9(three@0.152.2)
-      three: 0.152.2
+      shader-composer: 0.4.9(three@0.154.0)
+      three: 0.154.0
     dev: false
 
-  /shader-composer@0.4.9(three@0.152.2):
+  /shader-composer@0.4.9(three@0.154.0):
     resolution: {integrity: sha512-GZaT6Ky6rXSG7vsl3fFSFgRrB8mmVK0JBPx0+rMi6+gp0KSnpDAaLHmrkznmRD2Jfdm9RD7RpZ8aIAOqT3gvUw==}
     peerDependencies:
       three: '>=0.141.0'
     dependencies:
       fp-ts: 2.15.0
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
   /shebang-command@1.2.0:
@@ -6827,8 +6844,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /suspend-react@0.0.8(react@18.2.0):
-    resolution: {integrity: sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==}
+  /suspend-react@0.1.3(react@18.2.0):
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
     peerDependencies:
       react: '>=17.0'
     dependencies:
@@ -6872,15 +6889,15 @@ packages:
       string.prototype.replaceall: 1.0.6
     dev: false
 
-  /three-mesh-bvh@0.5.23(three@0.152.2):
-    resolution: {integrity: sha512-nyk+MskdyDgECqkxdv57UjazqqhrMi+Al9PxJN6yFtx1CTW4r0eCQ27FtyYKY5gCIWhxjtNfWYDPVy8lzx6LkA==}
+  /three-mesh-bvh@0.6.1(three@0.154.0):
+    resolution: {integrity: sha512-8fE6UwD5Ep8bAHd3Mp/Vw+7J3T10eGL95Lj98WQ9o3QEtAmlvmMhV+xxhrwYetfawzCPlgPYAB8Dl9+k1JveCQ==}
     peerDependencies:
-      three: '>= 0.123.0'
+      three: '>= 0.151.0'
     dependencies:
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
-  /three-stdlib@2.21.11(three@0.152.2):
+  /three-stdlib@2.21.11(three@0.154.0):
     resolution: {integrity: sha512-fFeaMOc3lpup4A/FrSKHmp/PNYmyxyV8dzMorJpYyZBdIGAn5BmokGSN9ei8t7Wv9thxCW+VLaxA6csxTl5MYg==}
     peerDependencies:
       three: '>=0.122.0'
@@ -6895,12 +6912,35 @@ packages:
       mmd-parser: 1.0.4
       opentype.js: 1.3.4
       potpack: 1.0.2
-      three: 0.152.2
+      three: 0.154.0
+      zstddec: 0.0.2
+    dev: false
+
+  /three-stdlib@2.23.13(three@0.154.0):
+    resolution: {integrity: sha512-WU4XHs4E6szAyoREzTs5bUAc1WFadiz5jRjNlA7aIIqf+raT4jfA320P0XmlyZz/wJwmpZnOuki4kAFsmadkTQ==}
+    peerDependencies:
+      three: '>=0.128.0'
+    dependencies:
+      '@types/draco3d': 1.4.2
+      '@types/offscreencanvas': 2019.7.0
+      '@types/webxr': 0.5.2
+      chevrotain: 10.3.0
+      draco3d: 1.5.3
+      fflate: 0.6.10
+      ktx-parse: 0.4.5
+      mmd-parser: 1.0.4
+      opentype.js: 1.3.4
+      potpack: 1.0.2
+      three: 0.154.0
       zstddec: 0.0.2
     dev: false
 
   /three@0.152.2:
     resolution: {integrity: sha512-Ff9zIpSfkkqcBcpdiFo2f35vA9ZucO+N8TNacJOqaEE6DrB0eufItVMib8bK8Pcju/ZNT6a7blE1GhTpkdsILw==}
+    dev: false
+
+  /three@0.154.0:
+    resolution: {integrity: sha512-Uzz8C/5GesJzv8i+Y2prEMYUwodwZySPcNhuJUdsVMH2Yn4Nm8qlbQe6qRN5fOhg55XB0WiLfTPBxVHxpE60ug==}
     dev: false
 
   /tiny-inflate@1.0.3:
@@ -6951,28 +6991,28 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /troika-three-text@0.47.1(three@0.152.2):
-    resolution: {integrity: sha512-/fPRUmxCkXxyUT8k6REC/aWeFzKbNr37ivrkrplSJNb3JcBUXvVt8MT0Ac5wTUvFsYTviYWprYS4/8Laen08WA==}
+  /troika-three-text@0.47.2(three@0.154.0):
+    resolution: {integrity: sha512-qylT0F+U7xGs+/PEf3ujBdJMYWbn0Qci0kLqI5BJG2kW1wdg4T1XSxneypnF05DxFqJhEzuaOR9S2SjiyknMng==}
     peerDependencies:
       three: '>=0.125.0'
     dependencies:
       bidi-js: 1.0.2
-      three: 0.152.2
-      troika-three-utils: 0.47.0(three@0.152.2)
-      troika-worker-utils: 0.47.0
+      three: 0.154.0
+      troika-three-utils: 0.47.2(three@0.154.0)
+      troika-worker-utils: 0.47.2
       webgl-sdf-generator: 1.1.1
     dev: false
 
-  /troika-three-utils@0.47.0(three@0.152.2):
-    resolution: {integrity: sha512-yoVTQxVbpQX3a55giIwqwq6hyJA6oYvq7kaNGwFTeicoWmTZCqqTbytafx1gcuL5umrtw5MYgsxYUSOha+xp5w==}
+  /troika-three-utils@0.47.2(three@0.154.0):
+    resolution: {integrity: sha512-/28plhCxfKtH7MSxEGx8e3b/OXU5A0xlwl+Sbdp0H8FXUHKZDoksduEKmjQayXYtxAyuUiCRunYIv/8Vi7aiyg==}
     peerDependencies:
       three: '>=0.125.0'
     dependencies:
-      three: 0.152.2
+      three: 0.154.0
     dev: false
 
-  /troika-worker-utils@0.47.0:
-    resolution: {integrity: sha512-PSUc9vunDEkbE23jpgXD3PcF96jQHKjgMjS+4o5g6DEK/ZAPTnldb+FNddhppawfUcuraMFrslo0GmIC8UpEmA==}
+  /troika-worker-utils@0.47.2:
+    resolution: {integrity: sha512-mzss4MeyzUkYBppn4x5cdAqrhBHFEuVmMMgLMTyFV23x6GvQMyo+/R5E5Lsbrt7WSt5RfvewjcwD1DChRTA9lA==}
     dev: false
 
   /ts-jest@29.1.0(@babel/core@7.21.8)(jest@29.5.0)(typescript@5.0.4):
@@ -7215,7 +7255,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: false
 
-  /vfx-composer-r3f@0.4.0(@react-three/fiber@8.13.0)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2):
+  /vfx-composer-r3f@0.4.0(@react-three/fiber@8.13.4)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0):
     resolution: {integrity: sha512-1x05PD22J3jomwPmDyiUl6/CcJ8mRVfsN9QkddhFH0thkOzg7ahy5VlDQlmcMtmtQ8Qz4N9nGEpzxxa+H+Tbwg==}
     peerDependencies:
       '@react-three/fiber': '>=8.0.27'
@@ -7226,27 +7266,27 @@ packages:
       '@hmans/use-const': 0.0.1(react@18.2.0)
       '@hmans/use-rerender': 0.0.2(react@18.2.0)
       '@hmans/use-version': 0.0.2(react@18.2.0)
-      '@react-three/fiber': 8.13.0(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
-      material-composer-r3f: 0.2.5(@react-three/fiber@8.13.0)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
+      '@react-three/fiber': 8.13.4(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
+      material-composer-r3f: 0.2.5(@react-three/fiber@8.13.4)(material-composer@0.2.6)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
       miniplex: 1.0.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      shader-composer: 0.4.9(three@0.152.2)
-      shader-composer-r3f: 0.4.5(@react-three/fiber@8.13.0)(react-dom@18.2.0)(react@18.2.0)(three@0.152.2)
-      three: 0.152.2
-      vfx-composer: 0.4.0(three@0.152.2)
+      shader-composer: 0.4.9(three@0.154.0)
+      shader-composer-r3f: 0.4.5(@react-three/fiber@8.13.4)(react-dom@18.2.0)(react@18.2.0)(three@0.154.0)
+      three: 0.154.0
+      vfx-composer: 0.4.0(three@0.154.0)
     transitivePeerDependencies:
       - material-composer
     dev: false
 
-  /vfx-composer@0.4.0(three@0.152.2):
+  /vfx-composer@0.4.0(three@0.154.0):
     resolution: {integrity: sha512-RCLjPHASLUHG/2r9WyPN00Ibje7byHFxrBZYmQzXL3mOgyd0Rtwb8jRhYnzdAmaatndjLR9JgHGzCg268SE4TQ==}
     peerDependencies:
       three: '>=0.141.0'
     dependencies:
-      material-composer: 0.2.6(three@0.152.2)
-      shader-composer: 0.4.9(three@0.152.2)
-      three: 0.152.2
+      material-composer: 0.2.6(three@0.154.0)
+      shader-composer: 0.4.9(three@0.154.0)
+      three: 0.154.0
     dev: false
 
   /vite@4.3.5:


### PR DESCRIPTION
This fixes the issue described #287, where the asteroids and bullets disappeared after a while. It turns out they were frustum culled once the player moved too far away from the starting position and the original geometry went out of the camera's frustum. 

I didn't dig into why this has only started happening recently, but I did check out 26d6682, and can confirm that it did not happen there, but also the `InstancedParticles` meshes `frustumCulled` was `false` there, whereas it was/is `true` on latest `main`.